### PR TITLE
fix: honor explicit spoiler format bans

### DIFF
--- a/packages/cards/latest-set/index.ts
+++ b/packages/cards/latest-set/index.ts
@@ -66,7 +66,7 @@
     typeText: "Ice Action - Attack",
 
     
-    bonds: [Bond.Earth],
+    bannedFormats: [Format.SilverAge],bonds: [Bond.Earth],
     cost: 3,createdExtras: ["frostbite"],
     defense: 3,
     
@@ -141,7 +141,7 @@
     typeText: "Brute Action - Attack",
 
     
-    
+    bannedFormats: [Format.SilverAge],
     cost: 3,
     defense: 3,
     
@@ -350,7 +350,7 @@ When this is pitched, create a Runechant token.`,
     typeText: "Illusionist Action - Attack",
 
     
-    
+    bannedFormats: [Format.SilverAge],
     cost: 2,createdExtras: ["spectral-shield"],
     defense: 3,
     
@@ -389,7 +389,7 @@ When this is pitched, create a Runechant token.`,
     classes: [Class.NotClassed],
     defaultImage: "IAR159-RF",
     firstReleaseDate: "2026-09-25",
-    legalFormats: [Format.Blitz,Format.Open,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Open,Format.UltimatePitFight],
     legalHeroes: [Hero.Baalghor],
     name: "Baalghor, Omen of the End",
     printings: [{
@@ -520,7 +520,7 @@ Attack action cards played from your banished zone get +3{p}.`,
     typeText: "Brute Action",
 
     
-    
+    bannedFormats: [Format.SilverAge],
     cost: 3,
     defense: 3,
     
@@ -1057,7 +1057,7 @@ When this hits, create a Blasmophet, the Insatiable Hunger token.
     typeText: "Shadow Runeblade Action",
 
     
-    
+    bannedFormats: [Format.SilverAge],
     cost: 0,createdExtras: ["gate-to-iarathael","runechant"],
     defense: 3,
     
@@ -1221,7 +1221,7 @@ At the beginning of each end phase, you may banish a card from your hand. Then i
     typeText: "Shadow Brute Action - Attack",
 
     
-    
+    bannedFormats: [Format.SilverAge],
     cost: 3,
     defense: 3,
     
@@ -1375,7 +1375,7 @@ When this hits a hero, you may banish target aura permanent they control.
     typeText: "Necromancer Defence Reaction",
 
     
-    
+    bannedFormats: [Format.SilverAge],
     cost: 0,
     defense: 2,
     
@@ -1448,7 +1448,7 @@ When this hits a hero, you may banish target aura permanent they control.
     typeText: "Shadow Necromancer Action - Aura",
 
     
-    
+    bannedFormats: [Format.SilverAge],
     cost: 0,
     defense: 3,
     
@@ -1523,7 +1523,7 @@ At the start of each turn, destroy this unless you put a zombie from your banish
     typeText: "Light Instant",
 
     
-    
+    bannedFormats: [Format.SilverAge],
     cost: 0,
     
     
@@ -1596,7 +1596,7 @@ At the start of each turn, destroy this unless you put a zombie from your banish
     typeText: "Generic Equipment - Head",
 
     
-    
+    bannedFormats: [Format.SilverAge],
     
     defense: 2,
     
@@ -1862,7 +1862,7 @@ At the start of each turn, destroy this unless you put a zombie from your banish
     classes: [Class.NotClassed],
     defaultImage: "IAR164",
     firstReleaseDate: "2026-09-25",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Baalghor,Hero.Chane,Hero.Levia,Hero.Malice,Hero.Viserai2,Hero.Vynnset],
     name: "Corrupt and Conquer",
     printings: [{
@@ -1900,7 +1900,7 @@ At the start of each turn, destroy this unless you put a zombie from your banish
     typeText: "Shadow Action - Attack",
 
     
-    
+    bannedFormats: [Format.ClassicConstructed],
     cost: 2,
     defense: 3,
     
@@ -2285,7 +2285,7 @@ When this hits, you may search your deck for a Darkest Hour, banish it, then shu
     typeText: "Guardian Action - Attack",
 
     
-    
+    bannedFormats: [Format.SilverAge],
     cost: 6,
     defense: 3,
     
@@ -2437,7 +2437,7 @@ When this hits a hero, they banish a card from their hand.
     typeText: "Necromancer Equipment - Legs",
 
     
-    
+    bannedFormats: [Format.SilverAge],
     
     defense: 1,
     
@@ -2743,7 +2743,7 @@ Your next Shadow attack this turn gets +1{p}. **Go again**
     typeText: "Assassin Action - Attack",
 
     
-    
+    bannedFormats: [Format.SilverAge],
     cost: 0,createdExtras: ["graphene-chelicera"],
     defense: 3,
     
@@ -3124,7 +3124,7 @@ Your next Shadow attack this turn gets +1{p}. **Go again**
     typeText: "Ranger Block - Trap",
 
     
-    
+    bannedFormats: [Format.SilverAge],
     
     defense: 3,
     
@@ -3495,7 +3495,7 @@ You may play an aura with Runechant in its name from your banished zone this tur
     typeText: "Shadow Necromancer Action - Attack",
 
     
-    
+    bannedFormats: [Format.SilverAge],
     cost: 0,createdExtras: ["gate-to-iarathael"],
     defense: 3,
     
@@ -3871,7 +3871,7 @@ You may play an aura with Runechant in its name from your banished zone this tur
     typeText: "Revered Guardian Instant - Aura",
 
     
-    
+    bannedFormats: [Format.SilverAge],
     cost: 1,
     defense: 3,
     
@@ -4311,7 +4311,7 @@ When the combat chain closes, if you've attacked with this, banish it.
     typeText: "Earth Action - Attack",
 
     
-    
+    bannedFormats: [Format.SilverAge],
     cost: 3,createdExtras: ["embodiment-of-earth","frostbite"],
     defense: 3,
     
@@ -4386,7 +4386,7 @@ When the combat chain closes, if you've attacked with this, banish it.
     typeText: "Shadow Brute Action - Attack",
 
     
-    
+    bannedFormats: [Format.SilverAge],
     cost: 1,
     defense: 3,
     
@@ -4558,7 +4558,7 @@ When the combat chain closes, if you've attacked with this, banish it.
     typeText: "Shadow Necromancer Hero - Young",
 
     
-    
+    bannedFormats: [Format.LivingLegend],
     createdExtras: ["corrupted-corpse"],
     
     
@@ -4621,7 +4621,7 @@ Whenever a zombie you control dies, banish it face-down and create a Corrupted C
     typeText: "Shadow Necromancer Hero",
 
     
-    
+    bannedFormats: [Format.SilverAge],
     createdExtras: ["corrupted-corpse"],
     
     
@@ -4883,7 +4883,7 @@ Whenever a zombie you control dies, banish it face-down and create a Corrupted C
     classes: [Class.NotClassed],
     defaultImage: "IAR166",
     firstReleaseDate: "2026-09-25",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Baalghor,Hero.Chane,Hero.Levia,Hero.Malice,Hero.Viserai2,Hero.Vynnset],
     name: "Open the Gate to i'Arathael",
     printings: [{
@@ -4921,7 +4921,7 @@ Whenever a zombie you control dies, banish it face-down and create a Corrupted C
     typeText: "Shadow Action - Attack",
 
     
-    
+    bannedFormats: [Format.ClassicConstructed],
     cost: 0,createdExtras: ["gate-to-iarathael"],
     defense: 3,
     
@@ -5681,7 +5681,7 @@ Banish the top card of your deck. If it's blue, create a Gate to i'Arathael toke
     typeText: "Shadow Equipment - Arms",
 
     
-    
+    bannedFormats: [Format.SilverAge],
     
     defense: 2,
     
@@ -6949,7 +6949,7 @@ At the beginning of your action phase or when you play an attack action card, de
     classes: [Class.Runeblade],
     defaultImage: "IAR149",
     firstReleaseDate: "2026-07-06",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Aurora,Hero.Aurora2,Hero.Briar,Hero.Chane,Hero.Florian,Hero.Viserai,Hero.Viserai2,Hero.Vynnset],
     name: "Runic Reaving",
     printings: [{
@@ -6987,7 +6987,7 @@ At the beginning of your action phase or when you play an attack action card, de
     typeText: "Runeblade Action - Attack",
 
     
-    
+    bannedFormats: [Format.SilverAge],
     cost: 0,createdExtras: ["runechant"],
     defense: 2,
     
@@ -7212,7 +7212,7 @@ At the beginning of your action phase or when you play an attack action card, de
     typeText: "Illusionist / Wizard Action - Attack",
 
     
-    
+    bannedFormats: [Format.SilverAge],
     cost: 0,
     defense: 2,
     
@@ -7650,7 +7650,7 @@ When this hits a hero, create a Runechant token.`,
     typeText: "Wizard Action - Aura",
 
     
-    
+    bannedFormats: [Format.SilverAge],
     cost: 0,createdExtras: ["ponder"],
     defense: 3,
     
@@ -7725,7 +7725,7 @@ At the beginning of your action phase, destroy this and create a Ponder token.`,
     typeText: "Shadow Runeblade Action - Attack",
 
     
-    
+    bannedFormats: [Format.SilverAge],
     cost: 0,
     defense: 3,
     
@@ -7804,7 +7804,7 @@ If this was played from your banished zone, it gets "When this attacks, you may 
     typeText: "Runeblade Action",
 
     
-    
+    bannedFormats: [Format.SilverAge],
     createdExtras: ["runechant"],
     defense: 3,
     
@@ -7879,7 +7879,7 @@ The next attack action card you play this turn costs {x} less to play and gets +
     typeText: "Shadow Resource - Gem",
 
     
-    
+    bannedFormats: [Format.SilverAge],
     
     
     
@@ -7954,7 +7954,7 @@ When this is pitched, lose 1{h}.`,
     typeText: "Ninja Action - Attack",
 
     
-    
+    bannedFormats: [Format.SilverAge],
     cost: 1,
     defense: 3,
     
@@ -8177,7 +8177,7 @@ When this is pitched, lose 1{h}.`,
     typeText: "Shadow Runeblade Action - Attack",
 
     
-    
+    bannedFormats: [Format.SilverAge],
     cost: 13,
     defense: 3,
     
@@ -8493,7 +8493,7 @@ When this hits a hero, deal 2 arcane damage to any target.
     typeText: "Shadow Runeblade Hero - Young",
 
     
-    
+    bannedFormats: [Format.LivingLegend],
     createdExtras: ["runechant"],
     
     
@@ -8566,7 +8566,7 @@ When this hits a hero, deal 2 arcane damage to any target.
     typeText: "Shadow Runeblade Hero",
 
     
-    
+    bannedFormats: [Format.SilverAge],
     createdExtras: ["runechant"],
     
     

--- a/packages/cards/scripts/Shared/legality/format.ts
+++ b/packages/cards/scripts/Shared/legality/format.ts
@@ -230,7 +230,7 @@ export const getBannedAndLegalFormats = (
       : ADULT_HERO_FORMATS.includes(format);
     const isLegalPerHeroAge = !isHero || heroMatchesFormat;
 
-    const isNotBanned = !bannedFormats || !bannedFormats.includes(format);
+    const isNotBanned = !isBannedInFormat && !bannedFormats.includes(format);
     const isAnException =
       format === Format.SilverAge &&
       SILVER_AGE_LEGAL_CARD_EXCEPTIONS.includes(card.name);
@@ -311,6 +311,10 @@ export const getConfirmedBannedAndLegalFormats = ({
   const confirmedBannedFormats = bannedFormats;
 
   const confirmedLegalFormats = legalFormats.filter((format) => {
+    if (bannedFormats?.includes(format)) {
+      return false;
+    }
+
     let isConfirmedLegal = true;
 
     const isLimited = [Format.Draft, Format.Sealed].includes(format);

--- a/packages/cards/scripts/Spoiled/mapper.ts
+++ b/packages/cards/scripts/Spoiled/mapper.ts
@@ -851,10 +851,9 @@ const getCardData = (card: ParsedCard): PreliminaryCard => {
     ({ bannedFormats, legalFormats } = getBannedAndLegalFormats(
       {
         ...card,
-        // classicConstructedBanned:
-        //   card.classicConstructedLegal === false ? true : false,
-        // livingLegendBanned: card.livingLegendLegal === false ? true : false,
-        // silverAgeBanned: card.silverAgeLegal === false ? true : false,
+        classicConstructedBanned: card.classicConstructedLegal === false,
+        livingLegendBanned: card.livingLegendLegal === false,
+        silverAgeBanned: card.silverAgeLegal === false,
       },
       classes,
       keywords,

--- a/packages/cards/src/index.ts
+++ b/packages/cards/src/index.ts
@@ -2882,7 +2882,7 @@ Create a Ponder token for each hero dealt damage this way.`,
     classes: [Class.Wizard],
     defaultImage: "U-ARC132",
     firstReleaseDate: "2020-03-27",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Blaze,Hero.Broscilio,Hero.Emperor,Hero.Iyslander,Hero.Kano,Hero.Oscilio,Hero.Verdance],
     name: "Aether Flare",
     printings: [{
@@ -3008,7 +3008,7 @@ The next card you play this turn with an arcane damage effect, instead deals tha
     classes: [Class.Wizard],
     defaultImage: "U-ARC133",
     firstReleaseDate: "2020-03-27",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Blaze,Hero.Broscilio,Hero.Iyslander,Hero.Kano,Hero.Oscilio,Hero.Verdance],
     name: "Aether Flare",
     printings: [{
@@ -3134,7 +3134,7 @@ The next card you play this turn with an arcane damage effect, instead deals tha
     classes: [Class.Wizard],
     defaultImage: "U-ARC134",
     firstReleaseDate: "2020-03-27",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Blaze,Hero.Broscilio,Hero.Iyslander,Hero.Kano,Hero.Oscilio,Hero.Verdance],
     name: "Aether Flare",
     printings: [{
@@ -3800,7 +3800,7 @@ Deal 3 arcane damage to any target. If this was **fused** and deals damage to a 
     classes: [Class.Runeblade],
     defaultImage: "U-MON230",
     firstReleaseDate: "2021-05-07",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Aurora,Hero.Aurora2,Hero.Briar,Hero.Chane,Hero.Florian,Hero.Taylor,Hero.Viserai,Hero.Viserai2,Hero.Vynnset],
     name: "Aether Ironweave",
     printings: [{
@@ -9702,7 +9702,7 @@ Banish the top card of your deck. If it has **combo**, you may play it this turn
     typeText: "Ice Action - Attack",
 
     
-    bonds: [Bond.Earth],
+    bannedFormats: [Format.SilverAge],bonds: [Bond.Earth],
     cost: 3,createdExtras: ["frostbite"],
     defense: 3,
     
@@ -11929,7 +11929,7 @@ The next attack action card you play this turn gets +1{p}. **Go again**
     typeText: "Brute Action - Attack",
 
     
-    
+    bannedFormats: [Format.SilverAge],
     cost: 3,
     defense: 3,
     
@@ -19039,7 +19039,7 @@ Draw 2 cards.`,
     classes: [Class.Generic],
     defaultImage: "U-ARC160",
     firstReleaseDate: "2020-03-27",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Arakni,Hero.Aurora,Hero.Aurora2,Hero.Azalea,Hero.Baalghor,Hero.Benji,Hero.Betsy,Hero.Blaze,Hero.Bolfar,Hero.Boltyn,Hero.Bravo,Hero.Brevant,Hero.Briar,Hero.Broscilio,Hero.Brutus,Hero.Chane,Hero.Cindra,Hero.Crackni,Hero.Crix,Hero.Dash,Hero.DataDoll,Hero.Dorinthea,Hero.Dromai,Hero.Enigma,Hero.Fai,Hero.Fang,Hero.Florian,Hero.Frankie,Hero.Genis,Hero.GravyBones,Hero.Hala,Hero.Ira,Hero.Iyslander,Hero.Jarl,Hero.Kano,Hero.Kassai,Hero.Katsu,Hero.Kavdaen,Hero.Kayo,Hero.Killjoy,Hero.Kox,Hero.Levia,Hero.Lexi,Hero.Librarian,Hero.Lyath,Hero.Malice,Hero.Marlynn,Hero.Maxx,Hero.Melody,Hero.Mortimer,Hero.Nuu,Hero.Oldhim,Hero.Olympia,Hero.Oscilio,Hero.Pleiades,Hero.Prism,Hero.Puffin,Hero.RKO,Hero.Reya,Hero.Rhinar,Hero.Riptide,Hero.Ruudi,Hero.Scurv,Hero.Shiyana,Hero.Slippy,Hero.Squizzy,Hero.Starvo,Hero.Taipanis,Hero.Taylor,Hero.Teklovossen,Hero.Terra,Hero.Theryon,Hero.Tuffnut,Hero.Uzuri,Hero.Valda,Hero.Verdance,Hero.Victor,Hero.Viserai,Hero.Viserai2,Hero.Vynnset,Hero.Yoji,Hero.Yorick,Hero.Zane,Hero.Zen,Hero.Zyggy],
     name: "Art of War",
     printings: [{
@@ -20062,7 +20062,7 @@ This enters the arena with a steam counter. At the start of your turn, destroy t
     typeText: "Illusionist Action - Attack",
 
     
-    
+    bannedFormats: [Format.SilverAge],
     cost: 2,createdExtras: ["spectral-shield"],
     defense: 3,
     
@@ -23130,7 +23130,7 @@ The next Brute attack action card you play this turn gets +1{p}.
     classes: [Class.Guardian],
     defaultImage: "U-ELE006",
     firstReleaseDate: "2021-09-24",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Jarl,Hero.Oldhim,Hero.Starvo,Hero.Terra],
     name: "Awakening",
     printings: [{
@@ -23717,7 +23717,7 @@ Search your deck for a Guardian attack action card with cost less than or equal 
     classes: [Class.NotClassed],
     defaultImage: "IAR159-RF",
     firstReleaseDate: "2026-09-25",
-    legalFormats: [Format.Blitz,Format.Open,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Open,Format.UltimatePitFight],
     legalHeroes: [Hero.Baalghor],
     name: "Baalghor, Omen of the End",
     printings: [{
@@ -26044,7 +26044,7 @@ If you've discarded a card with 6 or more {p} this turn, this gets +1{p}.`,
     classes: [Class.NotClassed],
     defaultImage: "U-ELE186",
     firstReleaseDate: "2021-09-24",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Aurora,Hero.Aurora2,Hero.Briar,Hero.Broscilio,Hero.Lexi,Hero.Oscilio,Hero.Starvo,Hero.Zyggy],
     name: "Ball Lightning",
     printings: [{
@@ -26155,7 +26155,7 @@ If you've discarded a card with 6 or more {p} this turn, this gets +1{p}.`,
     classes: [Class.NotClassed],
     defaultImage: "U-ELE187",
     firstReleaseDate: "2021-09-24",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Aurora,Hero.Aurora2,Hero.Briar,Hero.Broscilio,Hero.Lexi,Hero.Oscilio,Hero.Starvo,Hero.Zyggy],
     name: "Ball Lightning",
     printings: [{
@@ -26266,7 +26266,7 @@ If you've discarded a card with 6 or more {p} this turn, this gets +1{p}.`,
     classes: [Class.NotClassed],
     defaultImage: "U-ELE188",
     firstReleaseDate: "2021-09-24",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Aurora,Hero.Aurora2,Hero.Briar,Hero.Broscilio,Hero.Lexi,Hero.Oscilio,Hero.Starvo,Hero.Zyggy],
     name: "Ball Lightning",
     printings: [{
@@ -31305,7 +31305,7 @@ If you control 3 or more auras, this gets +3{p} and "When this hits a hero, dest
     typeText: "Brute Action",
 
     
-    
+    bannedFormats: [Format.SilverAge],
     cost: 3,
     defense: 3,
     
@@ -34673,7 +34673,7 @@ If you control a Vigor token, this gets +1{d}.
     classes: [Class.Runeblade],
     defaultImage: "SVI007",
     firstReleaseDate: "2026-02-13",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.UltimatePitFight],
     legalHeroes: [Hero.Aurora,Hero.Aurora2,Hero.Briar,Hero.Chane,Hero.Florian,Hero.Taylor,Hero.Viserai,Hero.Viserai2,Hero.Vynnset],
     name: "Beckoning Haunt",
     printings: [{
@@ -35093,7 +35093,7 @@ If a yellow card was **charged** this way, whenever an attack action card hits t
     classes: [Class.Assassin],
     defaultImage: "MST003",
     firstReleaseDate: "2024-05-31",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
     legalHeroes: [Hero.Nuu],
     name: "Beckoning Mistblade",
     printings: [{
@@ -35884,7 +35884,7 @@ You may discard an action card. If you discard an attack action card this way, s
     typeText: "Shadow Runeblade Action",
 
     
-    
+    bannedFormats: [Format.SilverAge],
     cost: 0,createdExtras: ["gate-to-iarathael","runechant"],
     defense: 3,
     
@@ -35921,7 +35921,7 @@ You may discard an action card. If you discard an attack action card this way, s
     classes: [Class.Generic],
     defaultImage: "U-MON266",
     firstReleaseDate: "2021-05-07",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Arakni,Hero.Aurora,Hero.Aurora2,Hero.Azalea,Hero.Baalghor,Hero.Benji,Hero.Betsy,Hero.Blaze,Hero.Bolfar,Hero.Boltyn,Hero.Bravo,Hero.Brevant,Hero.Briar,Hero.Broscilio,Hero.Brutus,Hero.Chane,Hero.Cindra,Hero.Crackni,Hero.Crix,Hero.Dash,Hero.DataDoll,Hero.Dorinthea,Hero.Dromai,Hero.Emperor,Hero.Enigma,Hero.Fai,Hero.Fang,Hero.Florian,Hero.Frankie,Hero.Genis,Hero.GravyBones,Hero.Hala,Hero.Ira,Hero.Iyslander,Hero.Jarl,Hero.Kano,Hero.Kassai,Hero.Katsu,Hero.Kavdaen,Hero.Kayo,Hero.Killjoy,Hero.Kox,Hero.Levia,Hero.Lexi,Hero.Librarian,Hero.Lyath,Hero.Malice,Hero.Marlynn,Hero.Maxx,Hero.Melody,Hero.Mortimer,Hero.Nuu,Hero.Oldhim,Hero.Olympia,Hero.Oscilio,Hero.Pleiades,Hero.Prism,Hero.Puffin,Hero.RKO,Hero.Reya,Hero.Rhinar,Hero.Riptide,Hero.Ruudi,Hero.Scurv,Hero.Shiyana,Hero.Slippy,Hero.Squizzy,Hero.Starvo,Hero.Taipanis,Hero.Taylor,Hero.Teklovossen,Hero.Terra,Hero.Theryon,Hero.Tuffnut,Hero.Uzuri,Hero.Valda,Hero.Verdance,Hero.Victor,Hero.Viserai,Hero.Viserai2,Hero.Vynnset,Hero.Yoji,Hero.Yorick,Hero.Zane,Hero.Zen,Hero.Zyggy],
     name: "Belittle",
     printings: [{
@@ -36034,7 +36034,7 @@ When the additional cost is paid, search your deck for a Minnowism, reveal it, p
     classes: [Class.Generic],
     defaultImage: "U-MON267",
     firstReleaseDate: "2021-05-07",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Arakni,Hero.Aurora,Hero.Aurora2,Hero.Azalea,Hero.Baalghor,Hero.Benji,Hero.Betsy,Hero.Blaze,Hero.Bolfar,Hero.Boltyn,Hero.Bravo,Hero.Brevant,Hero.Briar,Hero.Broscilio,Hero.Brutus,Hero.Chane,Hero.Cindra,Hero.Crackni,Hero.Crix,Hero.Dash,Hero.DataDoll,Hero.Dorinthea,Hero.Dromai,Hero.Enigma,Hero.Fai,Hero.Fang,Hero.Florian,Hero.Frankie,Hero.Genis,Hero.GravyBones,Hero.Hala,Hero.Ira,Hero.Iyslander,Hero.Jarl,Hero.Kano,Hero.Kassai,Hero.Katsu,Hero.Kavdaen,Hero.Kayo,Hero.Killjoy,Hero.Kox,Hero.Levia,Hero.Lexi,Hero.Librarian,Hero.Lyath,Hero.Malice,Hero.Marlynn,Hero.Maxx,Hero.Melody,Hero.Mortimer,Hero.Nuu,Hero.Oldhim,Hero.Olympia,Hero.Oscilio,Hero.Pleiades,Hero.Prism,Hero.Puffin,Hero.RKO,Hero.Reya,Hero.Rhinar,Hero.Riptide,Hero.Ruudi,Hero.Scurv,Hero.Shiyana,Hero.Slippy,Hero.Squizzy,Hero.Starvo,Hero.Taipanis,Hero.Taylor,Hero.Teklovossen,Hero.Terra,Hero.Theryon,Hero.Tuffnut,Hero.Uzuri,Hero.Valda,Hero.Verdance,Hero.Victor,Hero.Viserai,Hero.Viserai2,Hero.Vynnset,Hero.Yoji,Hero.Yorick,Hero.Zane,Hero.Zen,Hero.Zyggy],
     name: "Belittle",
     printings: [{
@@ -36147,7 +36147,7 @@ When the additional cost is paid, search your deck for a Minnowism, reveal it, p
     classes: [Class.Generic],
     defaultImage: "U-MON268",
     firstReleaseDate: "2021-05-07",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Arakni,Hero.Aurora,Hero.Aurora2,Hero.Azalea,Hero.Baalghor,Hero.Benji,Hero.Betsy,Hero.Blaze,Hero.Bolfar,Hero.Boltyn,Hero.Bravo,Hero.Brevant,Hero.Briar,Hero.Broscilio,Hero.Brutus,Hero.Chane,Hero.Cindra,Hero.Crackni,Hero.Crix,Hero.Dash,Hero.DataDoll,Hero.Dorinthea,Hero.Dromai,Hero.Enigma,Hero.Fai,Hero.Fang,Hero.Florian,Hero.Frankie,Hero.Genis,Hero.GravyBones,Hero.Hala,Hero.Ira,Hero.Iyslander,Hero.Jarl,Hero.Kano,Hero.Kassai,Hero.Katsu,Hero.Kavdaen,Hero.Kayo,Hero.Killjoy,Hero.Kox,Hero.Levia,Hero.Lexi,Hero.Librarian,Hero.Lyath,Hero.Malice,Hero.Marlynn,Hero.Maxx,Hero.Melody,Hero.Mortimer,Hero.Nuu,Hero.Oldhim,Hero.Olympia,Hero.Oscilio,Hero.Pleiades,Hero.Prism,Hero.Puffin,Hero.RKO,Hero.Reya,Hero.Rhinar,Hero.Riptide,Hero.Ruudi,Hero.Scurv,Hero.Shiyana,Hero.Slippy,Hero.Squizzy,Hero.Starvo,Hero.Taipanis,Hero.Taylor,Hero.Teklovossen,Hero.Terra,Hero.Theryon,Hero.Tuffnut,Hero.Uzuri,Hero.Valda,Hero.Verdance,Hero.Victor,Hero.Viserai,Hero.Viserai2,Hero.Vynnset,Hero.Yoji,Hero.Yorick,Hero.Zane,Hero.Zen,Hero.Zyggy],
     name: "Belittle",
     printings: [{
@@ -36951,7 +36951,7 @@ The next Runeblade attack action card you play this turn costs {r} less to play 
     classes: [Class.Brute],
     defaultImage: "DYN009",
     firstReleaseDate: "2022-11-11",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.LivingLegend,Format.Open,Format.UltimatePitFight],
     legalHeroes: [Hero.Kayo,Hero.Levia,Hero.RKO,Hero.Rhinar,Hero.Tuffnut],
     name: "Berserk",
     printings: [{
@@ -50548,7 +50548,7 @@ Target sword attack gets **go again** and "When this hits, create a Cintari Sell
     typeText: "Shadow Brute Action - Attack",
 
     
-    
+    bannedFormats: [Format.SilverAge],
     cost: 3,
     defense: 3,
     
@@ -52076,7 +52076,7 @@ If the discarded card has 6 or more {p}, draw 2 cards and this gets **go again**
     classes: [Class.Runeblade],
     defaultImage: "AVS004",
     firstReleaseDate: "2020-08-28",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.LivingLegend,Format.Open,Format.UltimatePitFight],
     legalHeroes: [Hero.Aurora,Hero.Aurora2,Hero.Briar,Hero.Chane,Hero.Florian,Hero.Taylor,Hero.Viserai,Hero.Viserai2,Hero.Vynnset],
     name: "Bloodsheath Skeleta",
     printings: [{
@@ -55660,7 +55660,7 @@ If you've **charged** this turn, this gets "When this hits, draw a card."`,
     classes: [Class.Assassin],
     defaultImage: "MST103",
     firstReleaseDate: "2024-05-31",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Arakni,Hero.Crackni,Hero.Mortimer,Hero.Nuu,Hero.Slippy,Hero.Uzuri],
     name: "Bonds of Agony",
     printings: [{
@@ -55741,7 +55741,7 @@ If you've played or activated 3 or more attack reactions this chain link, this g
     classes: [Class.Ninja],
     defaultImage: "OUT056",
     firstReleaseDate: "2023-03-24",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Benji,Hero.Cindra,Hero.Fai,Hero.Ira,Hero.Katsu,Hero.Zen],
     name: "Bonds of Ancestry",
     printings: [{
@@ -55835,7 +55835,7 @@ If you've played or activated 3 or more attack reactions this chain link, this g
     classes: [Class.Ninja],
     defaultImage: "OUT057",
     firstReleaseDate: "2023-03-24",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Benji,Hero.Cindra,Hero.Fai,Hero.Ira,Hero.Katsu,Hero.Zen],
     name: "Bonds of Ancestry",
     printings: [{
@@ -55914,7 +55914,7 @@ If you've played or activated 3 or more attack reactions this chain link, this g
     classes: [Class.Ninja],
     defaultImage: "OUT058",
     firstReleaseDate: "2023-03-24",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Benji,Hero.Cindra,Hero.Fai,Hero.Ira,Hero.Katsu,Hero.Zen],
     name: "Bonds of Ancestry",
     printings: [{
@@ -56574,7 +56574,7 @@ Whenever this banishes a card and this has banished another card with the same n
     typeText: "Necromancer Defence Reaction",
 
     
-    
+    bannedFormats: [Format.SilverAge],
     cost: 0,
     defense: 2,
     
@@ -59160,7 +59160,7 @@ When this is played from your banished zone, it gets +1{p}.
     classes: [Class.Generic],
     defaultImage: "AZL006",
     firstReleaseDate: "2020-03-27",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Arakni,Hero.Aurora,Hero.Aurora2,Hero.Azalea,Hero.Baalghor,Hero.Benji,Hero.Betsy,Hero.Blaze,Hero.Bolfar,Hero.Boltyn,Hero.Bravo,Hero.Brevant,Hero.Briar,Hero.Broscilio,Hero.Brutus,Hero.Chane,Hero.Cindra,Hero.Crackni,Hero.Crix,Hero.Dash,Hero.DataDoll,Hero.Dorinthea,Hero.Dromai,Hero.Emperor,Hero.Enigma,Hero.Fai,Hero.Fang,Hero.Florian,Hero.Frankie,Hero.Genis,Hero.GravyBones,Hero.Hala,Hero.Ira,Hero.Iyslander,Hero.Jarl,Hero.Kano,Hero.Kassai,Hero.Katsu,Hero.Kavdaen,Hero.Kayo,Hero.Killjoy,Hero.Kox,Hero.Levia,Hero.Lexi,Hero.Librarian,Hero.Lyath,Hero.Malice,Hero.Marlynn,Hero.Maxx,Hero.Melody,Hero.Mortimer,Hero.Nuu,Hero.Oldhim,Hero.Olympia,Hero.Oscilio,Hero.Pleiades,Hero.Prism,Hero.Puffin,Hero.RKO,Hero.Reya,Hero.Rhinar,Hero.Riptide,Hero.Ruudi,Hero.Scurv,Hero.Shiyana,Hero.Slippy,Hero.Squizzy,Hero.Starvo,Hero.Taipanis,Hero.Taylor,Hero.Teklovossen,Hero.Terra,Hero.Theryon,Hero.Tuffnut,Hero.Uzuri,Hero.Valda,Hero.Verdance,Hero.Victor,Hero.Viserai,Hero.Viserai2,Hero.Vynnset,Hero.Yoji,Hero.Yorick,Hero.Zane,Hero.Zen,Hero.Zyggy],
     name: "Bracers of Belief",
     printings: [{
@@ -60205,7 +60205,7 @@ If this was **fused**, the next attack action card you play this turn gets +1{p}
     classes: [Class.Ninja],
     defaultImage: "SFA012",
     firstReleaseDate: "2022-06-24",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
     legalHeroes: [Hero.Cindra,Hero.Fai],
     name: "Brand with Cinderclaw",
     printings: [{
@@ -60316,7 +60316,7 @@ If this was **fused**, the next attack action card you play this turn gets +1{p}
     classes: [Class.Ninja],
     defaultImage: "SFA029",
     firstReleaseDate: "2022-06-24",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
     legalHeroes: [Hero.Cindra,Hero.Fai],
     name: "Brand with Cinderclaw",
     printings: [{
@@ -60412,7 +60412,7 @@ If this was **fused**, the next attack action card you play this turn gets +1{p}
     classes: [Class.Ninja],
     defaultImage: "SFA031",
     firstReleaseDate: "2022-06-24",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
     legalHeroes: [Hero.Cindra,Hero.Fai],
     name: "Brand with Cinderclaw",
     printings: [{
@@ -64102,7 +64102,7 @@ The second time you play a non-attack action card each turn, create an Embodimen
     typeText: "Shadow Necromancer Action - Aura",
 
     
-    
+    bannedFormats: [Format.SilverAge],
     cost: 0,
     defense: 3,
     
@@ -71855,7 +71855,7 @@ You may put an arrow from your hand face-up into your arsenal.
     classes: [Class.NotClassed],
     defaultImage: "MON187-CF",
     firstReleaseDate: "2021-05-07",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Baalghor,Hero.Chane,Hero.Levia,Hero.Malice,Hero.Taylor,Hero.Viserai2,Hero.Vynnset],
     name: "Carrion Husk",
     printings: [{
@@ -72494,7 +72494,7 @@ At the start of your turn, if you have 13 or less {h}, banish this.
     classes: [Class.Generic],
     defaultImage: "U-CRU188",
     firstReleaseDate: "2020-08-28",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.LivingLegend,Format.Open,Format.SilverAge,Format.UltimatePitFight],
     legalHeroes: [Hero.Arakni,Hero.Aurora,Hero.Aurora2,Hero.Azalea,Hero.Baalghor,Hero.Benji,Hero.Betsy,Hero.Blaze,Hero.Bolfar,Hero.Boltyn,Hero.Bravo,Hero.Brevant,Hero.Briar,Hero.Broscilio,Hero.Brutus,Hero.Chane,Hero.Cindra,Hero.Crackni,Hero.Crix,Hero.Dash,Hero.DataDoll,Hero.Dorinthea,Hero.Dromai,Hero.Enigma,Hero.Fai,Hero.Fang,Hero.Florian,Hero.Frankie,Hero.Genis,Hero.GravyBones,Hero.Hala,Hero.Ira,Hero.Iyslander,Hero.Jarl,Hero.Kano,Hero.Kassai,Hero.Katsu,Hero.Kavdaen,Hero.Kayo,Hero.Killjoy,Hero.Kox,Hero.Levia,Hero.Lexi,Hero.Librarian,Hero.Lyath,Hero.Malice,Hero.Marlynn,Hero.Maxx,Hero.Melody,Hero.Mortimer,Hero.Nuu,Hero.Oldhim,Hero.Olympia,Hero.Oscilio,Hero.Pleiades,Hero.Prism,Hero.Puffin,Hero.RKO,Hero.Reya,Hero.Rhinar,Hero.Riptide,Hero.Ruudi,Hero.Scurv,Hero.Shiyana,Hero.Slippy,Hero.Squizzy,Hero.Starvo,Hero.Taipanis,Hero.Taylor,Hero.Teklovossen,Hero.Terra,Hero.Theryon,Hero.Tuffnut,Hero.Uzuri,Hero.Valda,Hero.Verdance,Hero.Victor,Hero.Viserai,Hero.Viserai2,Hero.Vynnset,Hero.Yoji,Hero.Yorick,Hero.Zane,Hero.Zen,Hero.Zyggy],
     name: "Cash In",
     printings: [{
@@ -74157,7 +74157,7 @@ If you've played another Wizard non-attack action card this turn, deal 3 arcane 
     typeText: "Light Instant",
 
     
-    
+    bannedFormats: [Format.SilverAge],
     cost: 0,
     
     
@@ -75053,7 +75053,7 @@ Cards and abilities cost opponents an additional {r} to play or activate.
     classes: [Class.NotClassed],
     defaultImage: "ROS077",
     firstReleaseDate: "2024-09-20",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Aurora,Hero.Aurora2,Hero.Briar,Hero.Broscilio,Hero.Lexi,Hero.Oscilio,Hero.Starvo,Hero.Zyggy],
     name: "Channel Lightning Valley",
     printings: [{
@@ -76372,7 +76372,7 @@ You may put a gold counter on Treasure Island.
     classes: [Class.Necromancer,Class.Pirate],
     defaultImage: "SEA048",
     firstReleaseDate: "2025-06-06",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.GravyBones],
     name: "Chart the High Seas",
     printings: [{
@@ -80932,7 +80932,7 @@ Cintari Sellsword can only attack if you've attacked with a weapon this turn.`,
     typeText: "Generic Equipment - Head",
 
     
-    
+    bannedFormats: [Format.SilverAge],
     
     defense: 2,
     
@@ -96683,7 +96683,7 @@ This enters the arena with 2 steam counters. At the start of your turn, destroy 
     classes: [Class.NotClassed],
     defaultImage: "IAR164",
     firstReleaseDate: "2026-09-25",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Baalghor,Hero.Chane,Hero.Levia,Hero.Malice,Hero.Viserai2,Hero.Vynnset],
     name: "Corrupt and Conquer",
     printings: [{
@@ -96733,7 +96733,7 @@ This enters the arena with 2 steam counters. At the start of your turn, destroy 
     typeText: "Shadow Action - Attack",
 
     
-    
+    bannedFormats: [Format.ClassicConstructed],
     cost: 2,
     defense: 3,
     
@@ -97605,7 +97605,7 @@ If 3 or more Chi were pitched to play this, Cosmic Awakening's {p} is 20.`,
     classes: [Class.Illusionist],
     defaultImage: "SEN002",
     firstReleaseDate: "2024-05-31",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
     legalHeroes: [Hero.Dromai,Hero.Enigma,Hero.Prism,Hero.Zyggy],
     name: "Cosmo, Scroll of Ancestral Tapestry",
     printings: [{
@@ -97731,7 +97731,7 @@ Your aura attacks with one or more +1{p} counters get **go again**.`,
     classes: [Class.Generic],
     defaultImage: "ROS223",
     firstReleaseDate: "2024-09-20",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Arakni,Hero.Aurora,Hero.Aurora2,Hero.Azalea,Hero.Baalghor,Hero.Benji,Hero.Betsy,Hero.Blaze,Hero.Bolfar,Hero.Boltyn,Hero.Bravo,Hero.Brevant,Hero.Briar,Hero.Broscilio,Hero.Brutus,Hero.Chane,Hero.Cindra,Hero.Crackni,Hero.Crix,Hero.Dash,Hero.DataDoll,Hero.Dorinthea,Hero.Dromai,Hero.Emperor,Hero.Enigma,Hero.Fai,Hero.Fang,Hero.Florian,Hero.Frankie,Hero.Genis,Hero.GravyBones,Hero.Hala,Hero.Ira,Hero.Iyslander,Hero.Jarl,Hero.Kano,Hero.Kassai,Hero.Katsu,Hero.Kavdaen,Hero.Kayo,Hero.Killjoy,Hero.Kox,Hero.Levia,Hero.Lexi,Hero.Librarian,Hero.Lyath,Hero.Malice,Hero.Marlynn,Hero.Maxx,Hero.Melody,Hero.Mortimer,Hero.Nuu,Hero.Oldhim,Hero.Olympia,Hero.Oscilio,Hero.Pleiades,Hero.Prism,Hero.Puffin,Hero.RKO,Hero.Reya,Hero.Rhinar,Hero.Riptide,Hero.Ruudi,Hero.Scurv,Hero.Shiyana,Hero.Slippy,Hero.Squizzy,Hero.Starvo,Hero.Taipanis,Hero.Taylor,Hero.Teklovossen,Hero.Terra,Hero.Theryon,Hero.Tuffnut,Hero.Uzuri,Hero.Valda,Hero.Verdance,Hero.Victor,Hero.Viserai,Hero.Viserai2,Hero.Vynnset,Hero.Yoji,Hero.Yorick,Hero.Zane,Hero.Zen,Hero.Zyggy],
     name: "Count Your Blessings",
     printings: [{
@@ -97825,7 +97825,7 @@ Your aura attacks with one or more +1{p} counters get **go again**.`,
     classes: [Class.Generic],
     defaultImage: "ROS224",
     firstReleaseDate: "2024-09-20",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Arakni,Hero.Aurora,Hero.Aurora2,Hero.Azalea,Hero.Baalghor,Hero.Benji,Hero.Betsy,Hero.Blaze,Hero.Bolfar,Hero.Boltyn,Hero.Bravo,Hero.Brevant,Hero.Briar,Hero.Broscilio,Hero.Brutus,Hero.Chane,Hero.Cindra,Hero.Crackni,Hero.Crix,Hero.Dash,Hero.DataDoll,Hero.Dorinthea,Hero.Dromai,Hero.Enigma,Hero.Fai,Hero.Fang,Hero.Florian,Hero.Frankie,Hero.Genis,Hero.GravyBones,Hero.Hala,Hero.Ira,Hero.Iyslander,Hero.Jarl,Hero.Kano,Hero.Kassai,Hero.Katsu,Hero.Kavdaen,Hero.Kayo,Hero.Killjoy,Hero.Kox,Hero.Levia,Hero.Lexi,Hero.Librarian,Hero.Lyath,Hero.Malice,Hero.Marlynn,Hero.Maxx,Hero.Melody,Hero.Mortimer,Hero.Nuu,Hero.Oldhim,Hero.Olympia,Hero.Oscilio,Hero.Pleiades,Hero.Prism,Hero.Puffin,Hero.RKO,Hero.Reya,Hero.Rhinar,Hero.Riptide,Hero.Ruudi,Hero.Scurv,Hero.Shiyana,Hero.Slippy,Hero.Squizzy,Hero.Starvo,Hero.Taipanis,Hero.Taylor,Hero.Teklovossen,Hero.Terra,Hero.Theryon,Hero.Tuffnut,Hero.Uzuri,Hero.Valda,Hero.Verdance,Hero.Victor,Hero.Viserai,Hero.Viserai2,Hero.Vynnset,Hero.Yoji,Hero.Yorick,Hero.Zane,Hero.Zen,Hero.Zyggy],
     name: "Count Your Blessings",
     printings: [{
@@ -97919,7 +97919,7 @@ Your aura attacks with one or more +1{p} counters get **go again**.`,
     classes: [Class.Generic],
     defaultImage: "ROS225",
     firstReleaseDate: "2024-09-20",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Arakni,Hero.Aurora,Hero.Aurora2,Hero.Azalea,Hero.Baalghor,Hero.Benji,Hero.Betsy,Hero.Blaze,Hero.Bolfar,Hero.Boltyn,Hero.Bravo,Hero.Brevant,Hero.Briar,Hero.Broscilio,Hero.Brutus,Hero.Chane,Hero.Cindra,Hero.Crackni,Hero.Crix,Hero.Dash,Hero.DataDoll,Hero.Dorinthea,Hero.Dromai,Hero.Enigma,Hero.Fai,Hero.Fang,Hero.Florian,Hero.Frankie,Hero.Genis,Hero.GravyBones,Hero.Hala,Hero.Ira,Hero.Iyslander,Hero.Jarl,Hero.Kano,Hero.Kassai,Hero.Katsu,Hero.Kavdaen,Hero.Kayo,Hero.Killjoy,Hero.Kox,Hero.Levia,Hero.Lexi,Hero.Librarian,Hero.Lyath,Hero.Malice,Hero.Marlynn,Hero.Maxx,Hero.Melody,Hero.Mortimer,Hero.Nuu,Hero.Oldhim,Hero.Olympia,Hero.Oscilio,Hero.Pleiades,Hero.Prism,Hero.Puffin,Hero.RKO,Hero.Reya,Hero.Rhinar,Hero.Riptide,Hero.Ruudi,Hero.Scurv,Hero.Shiyana,Hero.Slippy,Hero.Squizzy,Hero.Starvo,Hero.Taipanis,Hero.Taylor,Hero.Teklovossen,Hero.Terra,Hero.Theryon,Hero.Tuffnut,Hero.Uzuri,Hero.Valda,Hero.Verdance,Hero.Victor,Hero.Viserai,Hero.Viserai2,Hero.Vynnset,Hero.Yoji,Hero.Yorick,Hero.Zane,Hero.Zen,Hero.Zyggy],
     name: "Count Your Blessings",
     printings: [{
@@ -104026,7 +104026,7 @@ When this is equipped, create a Gold token.`,
     classes: [Class.NotClassed],
     defaultImage: "ELE115-CF",
     firstReleaseDate: "2021-09-24",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.GoldenAge,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Briar,Hero.Florian,Hero.Jarl,Hero.Oldhim,Hero.Starvo,Hero.Taylor,Hero.Terra,Hero.Verdance],
     name: "Crown of Seeds",
     printings: [{
@@ -104120,7 +104120,7 @@ When this is equipped, create a Gold token.`,
     classes: [Class.Wizard],
     defaultImage: "SBZ002",
     firstReleaseDate: "2020-03-27",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
     legalHeroes: [Hero.Blaze,Hero.Broscilio,Hero.Emperor,Hero.Iyslander,Hero.Kano,Hero.Oscilio,Hero.Verdance],
     name: "Crucible of Aetherweave",
     printings: [{
@@ -105355,7 +105355,7 @@ At the beginning of your action phase, destroy this, then your next attack this 
     typeText: "Guardian Action - Attack",
 
     
-    
+    bannedFormats: [Format.SilverAge],
     cost: 6,
     defense: 3,
     
@@ -109065,7 +109065,7 @@ Prevent the next X arcane damage that would be dealt to you this turn, where X i
     typeText: "Necromancer Equipment - Legs",
 
     
-    
+    bannedFormats: [Format.SilverAge],
     
     defense: 1,
     
@@ -112289,7 +112289,7 @@ If it has an aim counter, it gets "When this hits a hero, look at their hand and
     typeText: "Assassin Action - Attack",
 
     
-    
+    bannedFormats: [Format.SilverAge],
     cost: 0,createdExtras: ["graphene-chelicera"],
     defense: 3,
     
@@ -112326,7 +112326,7 @@ If it has an aim counter, it gets "When this hits a hero, look at their hand and
     classes: [Class.Runeblade],
     defaultImage: "AVS014",
     firstReleaseDate: "2024-09-20",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Aurora,Hero.Aurora2,Hero.Briar,Hero.Chane,Hero.Florian,Hero.Viserai,Hero.Viserai2,Hero.Vynnset],
     name: "Deadwood Dirge",
     printings: [{
@@ -112452,7 +112452,7 @@ If it has an aim counter, it gets "When this hits a hero, look at their hand and
     classes: [Class.Runeblade],
     defaultImage: "ROS156",
     firstReleaseDate: "2024-09-20",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Aurora,Hero.Aurora2,Hero.Briar,Hero.Chane,Hero.Florian,Hero.Viserai,Hero.Viserai2,Hero.Vynnset],
     name: "Deadwood Dirge",
     printings: [{
@@ -112533,7 +112533,7 @@ If it has an aim counter, it gets "When this hits a hero, look at their hand and
     classes: [Class.Runeblade],
     defaultImage: "ROS157",
     firstReleaseDate: "2024-09-20",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Aurora,Hero.Aurora2,Hero.Briar,Hero.Chane,Hero.Florian,Hero.Viserai,Hero.Viserai2,Hero.Vynnset],
     name: "Deadwood Dirge",
     printings: [{
@@ -113058,7 +113058,7 @@ If it has an aim counter, it gets "When this hits a hero, look at their hand and
     classes: [Class.Ranger],
     defaultImage: "SAZ002",
     firstReleaseDate: "2020-03-27",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
     legalHeroes: [Hero.Azalea,Hero.Lexi,Hero.Marlynn,Hero.Riptide],
     name: "Death Dealer",
     printings: [{
@@ -113515,7 +113515,7 @@ When this hits a hero, create a Frailty, Inertia, or Bloodrot Pox token under th
     classes: [Class.Runeblade],
     defaultImage: "DTD143",
     firstReleaseDate: "2023-07-14",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.UltimatePitFight],
     legalHeroes: [Hero.Chane,Hero.Viserai2,Hero.Vynnset],
     name: "Deathly Delight",
     printings: [{
@@ -113598,7 +113598,7 @@ When the combat chain closes, gain {h} equal to the number of heroes who have lo
     classes: [Class.Runeblade],
     defaultImage: "DTD144",
     firstReleaseDate: "2023-07-14",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.UltimatePitFight],
     legalHeroes: [Hero.Chane,Hero.Viserai2,Hero.Vynnset],
     name: "Deathly Delight",
     printings: [{
@@ -113681,7 +113681,7 @@ When the combat chain closes, gain {h} equal to the number of heroes who have lo
     classes: [Class.Runeblade],
     defaultImage: "DTD145",
     firstReleaseDate: "2023-07-14",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.UltimatePitFight],
     legalHeroes: [Hero.Chane,Hero.Viserai2,Hero.Vynnset],
     name: "Deathly Delight",
     printings: [{
@@ -119183,7 +119183,7 @@ Your next dagger attack this turn gets +1{p}.`,
     typeText: "Shadow Necromancer Action",
 
     
-    
+    bannedFormats: [Format.SilverAge],
     
     defense: 3,
     
@@ -129485,7 +129485,7 @@ If you've played a red card this turn, your dragon attacks get **go again**.`,
     classes: [Class.Generic],
     defaultImage: "U-WTR164",
     firstReleaseDate: "2019-10-11",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Arakni,Hero.Aurora,Hero.Aurora2,Hero.Azalea,Hero.Baalghor,Hero.Benji,Hero.Betsy,Hero.Blaze,Hero.Bolfar,Hero.Boltyn,Hero.Bravo,Hero.Brevant,Hero.Briar,Hero.Broscilio,Hero.Brutus,Hero.Chane,Hero.Cindra,Hero.Crackni,Hero.Crix,Hero.Dash,Hero.DataDoll,Hero.Dorinthea,Hero.Dromai,Hero.Emperor,Hero.Enigma,Hero.Fai,Hero.Fang,Hero.Florian,Hero.Frankie,Hero.Genis,Hero.GravyBones,Hero.Hala,Hero.Ira,Hero.Iyslander,Hero.Jarl,Hero.Kano,Hero.Kassai,Hero.Katsu,Hero.Kavdaen,Hero.Kayo,Hero.Killjoy,Hero.Kox,Hero.Levia,Hero.Lexi,Hero.Librarian,Hero.Lyath,Hero.Malice,Hero.Marlynn,Hero.Maxx,Hero.Melody,Hero.Mortimer,Hero.Nuu,Hero.Oldhim,Hero.Olympia,Hero.Oscilio,Hero.Pleiades,Hero.Prism,Hero.Puffin,Hero.RKO,Hero.Reya,Hero.Rhinar,Hero.Riptide,Hero.Ruudi,Hero.Scurv,Hero.Shiyana,Hero.Slippy,Hero.Squizzy,Hero.Starvo,Hero.Taipanis,Hero.Taylor,Hero.Teklovossen,Hero.Terra,Hero.Theryon,Hero.Tuffnut,Hero.Uzuri,Hero.Valda,Hero.Verdance,Hero.Victor,Hero.Viserai,Hero.Viserai2,Hero.Vynnset,Hero.Yoji,Hero.Yorick,Hero.Zane,Hero.Zen,Hero.Zyggy],
     name: "Drone of Brutality",
     printings: [{
@@ -129624,7 +129624,7 @@ If you've played a red card this turn, your dragon attacks get **go again**.`,
     classes: [Class.Generic],
     defaultImage: "U-WTR165",
     firstReleaseDate: "2019-10-11",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Arakni,Hero.Aurora,Hero.Aurora2,Hero.Azalea,Hero.Baalghor,Hero.Benji,Hero.Betsy,Hero.Blaze,Hero.Bolfar,Hero.Boltyn,Hero.Bravo,Hero.Brevant,Hero.Briar,Hero.Broscilio,Hero.Brutus,Hero.Chane,Hero.Cindra,Hero.Crackni,Hero.Crix,Hero.Dash,Hero.DataDoll,Hero.Dorinthea,Hero.Dromai,Hero.Enigma,Hero.Fai,Hero.Fang,Hero.Florian,Hero.Frankie,Hero.Genis,Hero.GravyBones,Hero.Hala,Hero.Ira,Hero.Iyslander,Hero.Jarl,Hero.Kano,Hero.Kassai,Hero.Katsu,Hero.Kavdaen,Hero.Kayo,Hero.Killjoy,Hero.Kox,Hero.Levia,Hero.Lexi,Hero.Librarian,Hero.Lyath,Hero.Malice,Hero.Marlynn,Hero.Maxx,Hero.Melody,Hero.Mortimer,Hero.Nuu,Hero.Oldhim,Hero.Olympia,Hero.Oscilio,Hero.Pleiades,Hero.Prism,Hero.Puffin,Hero.RKO,Hero.Reya,Hero.Rhinar,Hero.Riptide,Hero.Ruudi,Hero.Scurv,Hero.Shiyana,Hero.Slippy,Hero.Squizzy,Hero.Starvo,Hero.Taipanis,Hero.Taylor,Hero.Teklovossen,Hero.Terra,Hero.Theryon,Hero.Tuffnut,Hero.Uzuri,Hero.Valda,Hero.Verdance,Hero.Victor,Hero.Viserai,Hero.Viserai2,Hero.Vynnset,Hero.Yoji,Hero.Yorick,Hero.Zane,Hero.Zen,Hero.Zyggy],
     name: "Drone of Brutality",
     printings: [{
@@ -129733,7 +129733,7 @@ If you've played a red card this turn, your dragon attacks get **go again**.`,
     classes: [Class.Generic],
     defaultImage: "U-WTR166",
     firstReleaseDate: "2019-10-11",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Arakni,Hero.Aurora,Hero.Aurora2,Hero.Azalea,Hero.Baalghor,Hero.Benji,Hero.Betsy,Hero.Blaze,Hero.Bolfar,Hero.Boltyn,Hero.Bravo,Hero.Brevant,Hero.Briar,Hero.Broscilio,Hero.Brutus,Hero.Chane,Hero.Cindra,Hero.Crackni,Hero.Crix,Hero.Dash,Hero.DataDoll,Hero.Dorinthea,Hero.Dromai,Hero.Enigma,Hero.Fai,Hero.Fang,Hero.Florian,Hero.Frankie,Hero.Genis,Hero.GravyBones,Hero.Hala,Hero.Ira,Hero.Iyslander,Hero.Jarl,Hero.Kano,Hero.Kassai,Hero.Katsu,Hero.Kavdaen,Hero.Kayo,Hero.Killjoy,Hero.Kox,Hero.Levia,Hero.Lexi,Hero.Librarian,Hero.Lyath,Hero.Malice,Hero.Marlynn,Hero.Maxx,Hero.Melody,Hero.Mortimer,Hero.Nuu,Hero.Oldhim,Hero.Olympia,Hero.Oscilio,Hero.Pleiades,Hero.Prism,Hero.Puffin,Hero.RKO,Hero.Reya,Hero.Rhinar,Hero.Riptide,Hero.Ruudi,Hero.Scurv,Hero.Shiyana,Hero.Slippy,Hero.Squizzy,Hero.Starvo,Hero.Taipanis,Hero.Taylor,Hero.Teklovossen,Hero.Terra,Hero.Theryon,Hero.Tuffnut,Hero.Uzuri,Hero.Valda,Hero.Verdance,Hero.Victor,Hero.Viserai,Hero.Viserai2,Hero.Vynnset,Hero.Yoji,Hero.Yorick,Hero.Zane,Hero.Zen,Hero.Zyggy],
     name: "Drone of Brutality",
     printings: [{
@@ -131672,7 +131672,7 @@ If this has a +1{p} counter, reaction cards get -1{d} while defending it.`,
     classes: [Class.Runeblade],
     defaultImage: "U-ELE223",
     firstReleaseDate: "2021-09-24",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Aurora,Hero.Aurora2,Hero.Briar,Hero.Chane,Hero.Florian,Hero.Viserai,Hero.Viserai2,Hero.Vynnset],
     name: "Duskblade",
     printings: [{
@@ -134762,7 +134762,7 @@ At the beginning of your end phase, create an Embodiment of Earth token. Then, i
     classes: [Class.NotClassed],
     defaultImage: "U-MON188",
     firstReleaseDate: "2021-05-07",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Baalghor,Hero.Chane,Hero.Levia,Hero.Malice,Hero.Taylor,Hero.Viserai2,Hero.Vynnset],
     name: "Ebon Fold",
     printings: [{
@@ -135103,7 +135103,7 @@ When this is put into your graveyard from anywhere, your hero deals 1 arcane dam
     typeText: "Ranger Block - Trap",
 
     
-    
+    bannedFormats: [Format.SilverAge],
     
     defense: 3,
     
@@ -137661,7 +137661,7 @@ If this was played from arsenal, draw a card.
     classes: [Class.NotClassed],
     defaultImage: "AST019",
     firstReleaseDate: "2024-09-20",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Aurora,Hero.Aurora2,Hero.Briar,Hero.Broscilio,Hero.Lexi,Hero.Oscilio,Hero.Starvo,Hero.Zyggy],
     name: "Electromagnetic Somersault",
     printings: [{
@@ -137755,7 +137755,7 @@ If this was played from arsenal, draw a card.
     classes: [Class.NotClassed],
     defaultImage: "ROS086",
     firstReleaseDate: "2024-09-20",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Aurora,Hero.Aurora2,Hero.Briar,Hero.Broscilio,Hero.Lexi,Hero.Oscilio,Hero.Starvo,Hero.Zyggy],
     name: "Electromagnetic Somersault",
     printings: [{
@@ -137834,7 +137834,7 @@ If this was played from arsenal, draw a card.
     classes: [Class.NotClassed],
     defaultImage: "ROS087",
     firstReleaseDate: "2024-09-20",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Aurora,Hero.Aurora2,Hero.Briar,Hero.Broscilio,Hero.Lexi,Hero.Oscilio,Hero.Starvo,Hero.Zyggy],
     name: "Electromagnetic Somersault",
     printings: [{
@@ -160090,7 +160090,7 @@ Target attack gets +3{p}.`,
     classes: [Class.Generic],
     defaultImage: "U-ARC200",
     firstReleaseDate: "2020-03-27",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Arakni,Hero.Aurora,Hero.Aurora2,Hero.Azalea,Hero.Baalghor,Hero.Benji,Hero.Betsy,Hero.Blaze,Hero.Bolfar,Hero.Boltyn,Hero.Bravo,Hero.Brevant,Hero.Briar,Hero.Broscilio,Hero.Brutus,Hero.Chane,Hero.Cindra,Hero.Crackni,Hero.Crix,Hero.Dash,Hero.DataDoll,Hero.Dorinthea,Hero.Dromai,Hero.Emperor,Hero.Enigma,Hero.Fai,Hero.Fang,Hero.Florian,Hero.Frankie,Hero.Genis,Hero.GravyBones,Hero.Hala,Hero.Ira,Hero.Iyslander,Hero.Jarl,Hero.Kano,Hero.Kassai,Hero.Katsu,Hero.Kavdaen,Hero.Kayo,Hero.Killjoy,Hero.Kox,Hero.Levia,Hero.Lexi,Hero.Librarian,Hero.Lyath,Hero.Malice,Hero.Marlynn,Hero.Maxx,Hero.Melody,Hero.Mortimer,Hero.Nuu,Hero.Oldhim,Hero.Olympia,Hero.Oscilio,Hero.Pleiades,Hero.Prism,Hero.Puffin,Hero.RKO,Hero.Reya,Hero.Rhinar,Hero.Riptide,Hero.Ruudi,Hero.Scurv,Hero.Shiyana,Hero.Slippy,Hero.Squizzy,Hero.Starvo,Hero.Taipanis,Hero.Taylor,Hero.Teklovossen,Hero.Terra,Hero.Theryon,Hero.Tuffnut,Hero.Uzuri,Hero.Valda,Hero.Verdance,Hero.Victor,Hero.Viserai,Hero.Viserai2,Hero.Vynnset,Hero.Yoji,Hero.Yorick,Hero.Zane,Hero.Zen,Hero.Zyggy],
     name: "Fate Foreseen",
     printings: [{
@@ -160274,7 +160274,7 @@ Target attack gets +3{p}.`,
     classes: [Class.Generic],
     defaultImage: "U-ARC201",
     firstReleaseDate: "2020-03-27",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Arakni,Hero.Aurora,Hero.Aurora2,Hero.Azalea,Hero.Baalghor,Hero.Benji,Hero.Betsy,Hero.Blaze,Hero.Bolfar,Hero.Boltyn,Hero.Bravo,Hero.Brevant,Hero.Briar,Hero.Broscilio,Hero.Brutus,Hero.Chane,Hero.Cindra,Hero.Crackni,Hero.Crix,Hero.Dash,Hero.DataDoll,Hero.Dorinthea,Hero.Dromai,Hero.Enigma,Hero.Fai,Hero.Fang,Hero.Florian,Hero.Frankie,Hero.Genis,Hero.GravyBones,Hero.Hala,Hero.Ira,Hero.Iyslander,Hero.Jarl,Hero.Kano,Hero.Kassai,Hero.Katsu,Hero.Kavdaen,Hero.Kayo,Hero.Killjoy,Hero.Kox,Hero.Levia,Hero.Lexi,Hero.Librarian,Hero.Lyath,Hero.Malice,Hero.Marlynn,Hero.Maxx,Hero.Melody,Hero.Mortimer,Hero.Nuu,Hero.Oldhim,Hero.Olympia,Hero.Oscilio,Hero.Pleiades,Hero.Prism,Hero.Puffin,Hero.RKO,Hero.Reya,Hero.Rhinar,Hero.Riptide,Hero.Ruudi,Hero.Scurv,Hero.Shiyana,Hero.Slippy,Hero.Squizzy,Hero.Starvo,Hero.Taipanis,Hero.Taylor,Hero.Teklovossen,Hero.Terra,Hero.Theryon,Hero.Tuffnut,Hero.Uzuri,Hero.Valda,Hero.Verdance,Hero.Victor,Hero.Viserai,Hero.Viserai2,Hero.Vynnset,Hero.Yoji,Hero.Yorick,Hero.Zane,Hero.Zen,Hero.Zyggy],
     name: "Fate Foreseen",
     printings: [{
@@ -160398,7 +160398,7 @@ Target attack gets +3{p}.`,
     classes: [Class.Generic],
     defaultImage: "U-ARC202",
     firstReleaseDate: "2020-03-27",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Arakni,Hero.Aurora,Hero.Aurora2,Hero.Azalea,Hero.Baalghor,Hero.Benji,Hero.Betsy,Hero.Blaze,Hero.Bolfar,Hero.Boltyn,Hero.Bravo,Hero.Brevant,Hero.Briar,Hero.Broscilio,Hero.Brutus,Hero.Chane,Hero.Cindra,Hero.Crackni,Hero.Crix,Hero.Dash,Hero.DataDoll,Hero.Dorinthea,Hero.Dromai,Hero.Enigma,Hero.Fai,Hero.Fang,Hero.Florian,Hero.Frankie,Hero.Genis,Hero.GravyBones,Hero.Hala,Hero.Ira,Hero.Iyslander,Hero.Jarl,Hero.Kano,Hero.Kassai,Hero.Katsu,Hero.Kavdaen,Hero.Kayo,Hero.Killjoy,Hero.Kox,Hero.Levia,Hero.Lexi,Hero.Librarian,Hero.Lyath,Hero.Malice,Hero.Marlynn,Hero.Maxx,Hero.Melody,Hero.Mortimer,Hero.Nuu,Hero.Oldhim,Hero.Olympia,Hero.Oscilio,Hero.Pleiades,Hero.Prism,Hero.Puffin,Hero.RKO,Hero.Reya,Hero.Rhinar,Hero.Riptide,Hero.Ruudi,Hero.Scurv,Hero.Shiyana,Hero.Slippy,Hero.Squizzy,Hero.Starvo,Hero.Taipanis,Hero.Taylor,Hero.Teklovossen,Hero.Terra,Hero.Theryon,Hero.Tuffnut,Hero.Uzuri,Hero.Valda,Hero.Verdance,Hero.Victor,Hero.Viserai,Hero.Viserai2,Hero.Vynnset,Hero.Yoji,Hero.Yorick,Hero.Zane,Hero.Zen,Hero.Zyggy],
     name: "Fate Foreseen",
     printings: [{
@@ -162994,7 +162994,7 @@ If this was played from arsenal, it gets **go again**.`,
     classes: [Class.Generic],
     defaultImage: "SEA212",
     firstReleaseDate: "2025-05-30",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Arakni,Hero.Aurora,Hero.Aurora2,Hero.Azalea,Hero.Baalghor,Hero.Benji,Hero.Betsy,Hero.Blaze,Hero.Bolfar,Hero.Boltyn,Hero.Bravo,Hero.Brevant,Hero.Briar,Hero.Broscilio,Hero.Brutus,Hero.Chane,Hero.Cindra,Hero.Crackni,Hero.Crix,Hero.Dash,Hero.DataDoll,Hero.Dorinthea,Hero.Dromai,Hero.Emperor,Hero.Enigma,Hero.Fai,Hero.Fang,Hero.Florian,Hero.Frankie,Hero.Genis,Hero.GravyBones,Hero.Hala,Hero.Ira,Hero.Iyslander,Hero.Jarl,Hero.Kano,Hero.Kassai,Hero.Katsu,Hero.Kavdaen,Hero.Kayo,Hero.Killjoy,Hero.Kox,Hero.Levia,Hero.Lexi,Hero.Librarian,Hero.Lyath,Hero.Malice,Hero.Marlynn,Hero.Maxx,Hero.Melody,Hero.Mortimer,Hero.Nuu,Hero.Oldhim,Hero.Olympia,Hero.Oscilio,Hero.Pleiades,Hero.Prism,Hero.Puffin,Hero.RKO,Hero.Reya,Hero.Rhinar,Hero.Riptide,Hero.Ruudi,Hero.Scurv,Hero.Shiyana,Hero.Slippy,Hero.Squizzy,Hero.Starvo,Hero.Taipanis,Hero.Taylor,Hero.Teklovossen,Hero.Terra,Hero.Theryon,Hero.Tuffnut,Hero.Uzuri,Hero.Valda,Hero.Verdance,Hero.Victor,Hero.Viserai,Hero.Viserai2,Hero.Vynnset,Hero.Yoji,Hero.Yorick,Hero.Zane,Hero.Zen,Hero.Zyggy],
     name: "Fiddler's Green",
     printings: [{
@@ -163133,7 +163133,7 @@ If this was played from arsenal, it gets **go again**.`,
     classes: [Class.Generic],
     defaultImage: "SEA213",
     firstReleaseDate: "2025-06-06",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Arakni,Hero.Aurora,Hero.Aurora2,Hero.Azalea,Hero.Baalghor,Hero.Benji,Hero.Betsy,Hero.Blaze,Hero.Bolfar,Hero.Boltyn,Hero.Bravo,Hero.Brevant,Hero.Briar,Hero.Broscilio,Hero.Brutus,Hero.Chane,Hero.Cindra,Hero.Crackni,Hero.Crix,Hero.Dash,Hero.DataDoll,Hero.Dorinthea,Hero.Dromai,Hero.Enigma,Hero.Fai,Hero.Fang,Hero.Florian,Hero.Frankie,Hero.Genis,Hero.GravyBones,Hero.Hala,Hero.Ira,Hero.Iyslander,Hero.Jarl,Hero.Kano,Hero.Kassai,Hero.Katsu,Hero.Kavdaen,Hero.Kayo,Hero.Killjoy,Hero.Kox,Hero.Levia,Hero.Lexi,Hero.Librarian,Hero.Lyath,Hero.Malice,Hero.Marlynn,Hero.Maxx,Hero.Melody,Hero.Mortimer,Hero.Nuu,Hero.Oldhim,Hero.Olympia,Hero.Oscilio,Hero.Pleiades,Hero.Prism,Hero.Puffin,Hero.RKO,Hero.Reya,Hero.Rhinar,Hero.Riptide,Hero.Ruudi,Hero.Scurv,Hero.Shiyana,Hero.Slippy,Hero.Squizzy,Hero.Starvo,Hero.Taipanis,Hero.Taylor,Hero.Teklovossen,Hero.Terra,Hero.Theryon,Hero.Tuffnut,Hero.Uzuri,Hero.Valda,Hero.Verdance,Hero.Victor,Hero.Viserai,Hero.Viserai2,Hero.Vynnset,Hero.Yoji,Hero.Yorick,Hero.Zane,Hero.Zen,Hero.Zyggy],
     name: "Fiddler's Green",
     printings: [{
@@ -163212,7 +163212,7 @@ If this was played from arsenal, it gets **go again**.`,
     classes: [Class.Generic],
     defaultImage: "SEA214",
     firstReleaseDate: "2025-06-06",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Arakni,Hero.Aurora,Hero.Aurora2,Hero.Azalea,Hero.Baalghor,Hero.Benji,Hero.Betsy,Hero.Blaze,Hero.Bolfar,Hero.Boltyn,Hero.Bravo,Hero.Brevant,Hero.Briar,Hero.Broscilio,Hero.Brutus,Hero.Chane,Hero.Cindra,Hero.Crackni,Hero.Crix,Hero.Dash,Hero.DataDoll,Hero.Dorinthea,Hero.Dromai,Hero.Enigma,Hero.Fai,Hero.Fang,Hero.Florian,Hero.Frankie,Hero.Genis,Hero.GravyBones,Hero.Hala,Hero.Ira,Hero.Iyslander,Hero.Jarl,Hero.Kano,Hero.Kassai,Hero.Katsu,Hero.Kavdaen,Hero.Kayo,Hero.Killjoy,Hero.Kox,Hero.Levia,Hero.Lexi,Hero.Librarian,Hero.Lyath,Hero.Malice,Hero.Marlynn,Hero.Maxx,Hero.Melody,Hero.Mortimer,Hero.Nuu,Hero.Oldhim,Hero.Olympia,Hero.Oscilio,Hero.Pleiades,Hero.Prism,Hero.Puffin,Hero.RKO,Hero.Reya,Hero.Rhinar,Hero.Riptide,Hero.Ruudi,Hero.Scurv,Hero.Shiyana,Hero.Slippy,Hero.Squizzy,Hero.Starvo,Hero.Taipanis,Hero.Taylor,Hero.Teklovossen,Hero.Terra,Hero.Theryon,Hero.Tuffnut,Hero.Uzuri,Hero.Valda,Hero.Verdance,Hero.Victor,Hero.Viserai,Hero.Viserai2,Hero.Vynnset,Hero.Yoji,Hero.Yorick,Hero.Zane,Hero.Zen,Hero.Zyggy],
     name: "Fiddler's Green",
     printings: [{
@@ -170260,7 +170260,7 @@ If it has an aim counter, it gets "Yellow cards get -1{d} while defending this."
     classes: [Class.Ninja],
     defaultImage: "ASR017",
     firstReleaseDate: "2019-10-11",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Benji,Hero.Cindra,Hero.Fai,Hero.Ira,Hero.Katsu,Hero.Zen],
     name: "Flic Flak",
     printings: [{
@@ -170429,7 +170429,7 @@ If it has an aim counter, it gets "Yellow cards get -1{d} while defending this."
     classes: [Class.Ninja],
     defaultImage: "U-WTR093",
     firstReleaseDate: "2019-10-11",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Benji,Hero.Cindra,Hero.Fai,Hero.Ira,Hero.Katsu,Hero.Zen],
     name: "Flic Flak",
     printings: [{
@@ -170568,7 +170568,7 @@ If it has an aim counter, it gets "Yellow cards get -1{d} while defending this."
     classes: [Class.Ninja],
     defaultImage: "U-WTR094",
     firstReleaseDate: "2019-10-11",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Benji,Hero.Cindra,Hero.Fai,Hero.Ira,Hero.Katsu,Hero.Zen],
     name: "Flic Flak",
     printings: [{
@@ -172822,7 +172822,7 @@ When this attacks, create a Quicken token.`,
     classes: [Class.NotClassed],
     defaultImage: "TER017",
     firstReleaseDate: "2024-08-01",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.UltimatePitFight],
     legalHeroes: [Hero.Briar,Hero.Florian,Hero.Jarl,Hero.Oldhim,Hero.Starvo,Hero.Terra,Hero.Verdance],
     name: "Flourish",
     printings: [{
@@ -172918,7 +172918,7 @@ When this attacks, create a Quicken token.`,
     classes: [Class.NotClassed],
     defaultImage: "TER024",
     firstReleaseDate: "2024-08-01",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.UltimatePitFight],
     legalHeroes: [Hero.Briar,Hero.Florian,Hero.Jarl,Hero.Oldhim,Hero.Starvo,Hero.Terra,Hero.Verdance],
     name: "Flourish",
     printings: [{
@@ -176446,7 +176446,7 @@ At the beginning of your action phase, destroy this.`,
     typeText: "Shadow Necromancer Action - Attack",
 
     
-    
+    bannedFormats: [Format.SilverAge],
     cost: 0,createdExtras: ["gate-to-iarathael"],
     defense: 3,
     
@@ -182430,7 +182430,7 @@ Create a Runechant token.
     classes: [Class.Runeblade],
     defaultImage: "U-MON155",
     firstReleaseDate: "2021-05-07",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
     legalHeroes: [Hero.Chane,Hero.Viserai2,Hero.Vynnset],
     name: "Galaxxi Black",
     printings: [{
@@ -191609,7 +191609,7 @@ This counts as a Gold.
     classes: [Class.Pirate],
     defaultImage: "SGB011",
     firstReleaseDate: "2025-06-06",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
     legalHeroes: [Hero.GravyBones,Hero.Marlynn,Hero.Puffin,Hero.Scurv],
     name: "Golden Tipple",
     printings: [{
@@ -191720,7 +191720,7 @@ This counts as a Gold.
     classes: [Class.Pirate],
     defaultImage: "SGB014",
     firstReleaseDate: "2025-06-06",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
     legalHeroes: [Hero.GravyBones,Hero.Marlynn,Hero.Puffin,Hero.Scurv],
     name: "Golden Tipple",
     printings: [{
@@ -192415,7 +192415,7 @@ Create a Golden Cog token.`,
     classes: [Class.Generic],
     defaultImage: "ARR005-RF",
     firstReleaseDate: "2019-10-11",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Arakni,Hero.Aurora,Hero.Aurora2,Hero.Azalea,Hero.Baalghor,Hero.Benji,Hero.Betsy,Hero.Blaze,Hero.Bolfar,Hero.Boltyn,Hero.Bravo,Hero.Brevant,Hero.Briar,Hero.Broscilio,Hero.Brutus,Hero.Chane,Hero.Cindra,Hero.Crackni,Hero.Crix,Hero.Dash,Hero.DataDoll,Hero.Dorinthea,Hero.Dromai,Hero.Emperor,Hero.Enigma,Hero.Fai,Hero.Fang,Hero.Florian,Hero.Frankie,Hero.Genis,Hero.GravyBones,Hero.Hala,Hero.Ira,Hero.Iyslander,Hero.Jarl,Hero.Kano,Hero.Kassai,Hero.Katsu,Hero.Kavdaen,Hero.Kayo,Hero.Killjoy,Hero.Kox,Hero.Levia,Hero.Lexi,Hero.Librarian,Hero.Lyath,Hero.Malice,Hero.Marlynn,Hero.Maxx,Hero.Melody,Hero.Mortimer,Hero.Nuu,Hero.Oldhim,Hero.Olympia,Hero.Oscilio,Hero.Pleiades,Hero.Prism,Hero.Puffin,Hero.RKO,Hero.Reya,Hero.Rhinar,Hero.Riptide,Hero.Ruudi,Hero.Scurv,Hero.Shiyana,Hero.Slippy,Hero.Squizzy,Hero.Starvo,Hero.Taipanis,Hero.Taylor,Hero.Teklovossen,Hero.Terra,Hero.Theryon,Hero.Tuffnut,Hero.Uzuri,Hero.Valda,Hero.Verdance,Hero.Victor,Hero.Viserai,Hero.Viserai2,Hero.Vynnset,Hero.Yoji,Hero.Yorick,Hero.Zane,Hero.Zen,Hero.Zyggy],
     name: "Goliath Gauntlet",
     printings: [{
@@ -201952,7 +201952,7 @@ If this is tapped, cards cost {r} less to play, this doesn't untap during the en
     typeText: "Revered Guardian Instant - Aura",
 
     
-    
+    bannedFormats: [Format.SilverAge],
     cost: 1,
     defense: 3,
     
@@ -204466,7 +204466,7 @@ Gain 1{h}. Gain 1{h}. Gain 1{h}.
     classes: [Class.Generic],
     defaultImage: "MPG119",
     firstReleaseDate: "2019-10-11",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Arakni,Hero.Aurora,Hero.Aurora2,Hero.Azalea,Hero.Baalghor,Hero.Benji,Hero.Betsy,Hero.Blaze,Hero.Bolfar,Hero.Boltyn,Hero.Bravo,Hero.Brevant,Hero.Briar,Hero.Broscilio,Hero.Brutus,Hero.Chane,Hero.Cindra,Hero.Crackni,Hero.Crix,Hero.Dash,Hero.DataDoll,Hero.Dorinthea,Hero.Dromai,Hero.Emperor,Hero.Enigma,Hero.Fai,Hero.Fang,Hero.Florian,Hero.Frankie,Hero.Genis,Hero.GravyBones,Hero.Hala,Hero.Ira,Hero.Iyslander,Hero.Jarl,Hero.Kano,Hero.Kassai,Hero.Katsu,Hero.Kavdaen,Hero.Kayo,Hero.Killjoy,Hero.Kox,Hero.Levia,Hero.Lexi,Hero.Librarian,Hero.Lyath,Hero.Malice,Hero.Marlynn,Hero.Maxx,Hero.Melody,Hero.Mortimer,Hero.Nuu,Hero.Oldhim,Hero.Olympia,Hero.Oscilio,Hero.Pleiades,Hero.Prism,Hero.Puffin,Hero.RKO,Hero.Reya,Hero.Rhinar,Hero.Riptide,Hero.Ruudi,Hero.Scurv,Hero.Shiyana,Hero.Slippy,Hero.Squizzy,Hero.Starvo,Hero.Taipanis,Hero.Taylor,Hero.Teklovossen,Hero.Terra,Hero.Theryon,Hero.Tuffnut,Hero.Uzuri,Hero.Valda,Hero.Verdance,Hero.Victor,Hero.Viserai,Hero.Viserai2,Hero.Vynnset,Hero.Yoji,Hero.Yorick,Hero.Zane,Hero.Zen,Hero.Zyggy],
     name: "Heartened Cross Strap",
     printings: [{
@@ -205960,7 +205960,7 @@ Gain 1{h}. Gain 1{h}. Gain 1{h}.
     classes: [Class.Mechanologist],
     defaultImage: "AIO004-RF",
     firstReleaseDate: "2024-10-18",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.LivingLegend,Format.Open,Format.UltimatePitFight],
     legalHeroes: [Hero.Dash,Hero.DataDoll,Hero.Maxx,Hero.Puffin,Hero.Taylor,Hero.Teklovossen],
     name: "Heavy Industry Power Plant",
     printings: [{
@@ -212753,7 +212753,7 @@ Whenever this attacks, it deals damage to you equal to 6 minus the number of car
     classes: [Class.Mechanologist],
     defaultImage: "U-ARC006",
     firstReleaseDate: "2020-03-27",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Dash,Hero.DataDoll,Hero.Maxx,Hero.Puffin,Hero.Teklovossen],
     name: "High Octane",
     printings: [{
@@ -217173,7 +217173,7 @@ If it has 3 or more +1{p} counters, you may put an attack reaction card from you
     classes: [Class.Ranger],
     defaultImage: "U-ELE214",
     firstReleaseDate: "2021-09-24",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Azalea,Hero.Lexi,Hero.Marlynn,Hero.Riptide,Hero.Taylor],
     name: "Honing Hood",
     printings: [{
@@ -223418,7 +223418,7 @@ At the beginning of your end phase, destroy this.`,
     typeText: "Earth Action - Attack",
 
     
-    
+    bannedFormats: [Format.SilverAge],
     cost: 3,createdExtras: ["embodiment-of-earth","frostbite"],
     defense: 3,
     
@@ -230226,7 +230226,7 @@ When this hits a hero, banish the top card of their deck. You may play it until 
     typeText: "Shadow Brute Action - Attack",
 
     
-    
+    bannedFormats: [Format.SilverAge],
     cost: 1,
     defense: 3,
     
@@ -234746,7 +234746,7 @@ Banish up to 2 cards in an opponent's graveyard. If an attack action card and a 
     classes: [Class.Ninja],
     defaultImage: "TCC077-RF",
     firstReleaseDate: "2019-08-31",
-    legalFormats: [Format.Blitz,Format.Open,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Open,Format.UltimatePitFight],
     legalHeroes: [Hero.Ira],
     name: "Ira, Crimson Haze",
     printings: [{
@@ -240674,7 +240674,7 @@ When this attacks, if it **scrapped** a card, this gets +1{p}.`,
     classes: [Class.Wizard],
     defaultImage: "U-ARC114",
     firstReleaseDate: "2020-03-27",
-    legalFormats: [Format.Blitz,Format.Draft,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Kano],
     name: "Kano",
     printings: [{
@@ -241934,7 +241934,7 @@ const cards4: Card[] = [{
     classes: [Class.Brute],
     defaultImage: "SKA001",
     firstReleaseDate: "2024-02-02",
-    legalFormats: [Format.Blitz,Format.Draft,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Kayo],
     name: "Kayo",
     printings: [{
@@ -244342,7 +244342,7 @@ At the beginning of the end phase, if no hero has gained {r} or {h} from an effe
     classes: [Class.Wizard],
     defaultImage: "EVR121",
     firstReleaseDate: "2022-02-04",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Open,Format.UltimatePitFight],
     legalHeroes: [Hero.Blaze,Hero.Broscilio,Hero.Emperor,Hero.Iyslander,Hero.Kano,Hero.Oscilio,Hero.Verdance],
     name: "Kraken's Aethervein",
     printings: [{
@@ -258267,7 +258267,7 @@ If you've **charged** this turn, you may attack with each weapon you control an 
     classes: [Class.Illusionist],
     defaultImage: "APR002",
     firstReleaseDate: "2021-05-07",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Prism],
     name: "Luminaris",
     printings: [{
@@ -258423,7 +258423,7 @@ If there is a yellow card in your pitch zone, your Illusionist attacks get **go 
     classes: [Class.Illusionist],
     defaultImage: "HVY254",
     firstReleaseDate: "2024-02-02",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.UltimatePitFight],
     legalHeroes: [Hero.Prism],
     name: "Luminaris, Angel's Glow",
     printings: [{
@@ -258502,7 +258502,7 @@ If there is a yellow card in your pitch zone, your Illusionist attacks get **go 
     classes: [Class.Illusionist],
     defaultImage: "SAT003",
     firstReleaseDate: "2023-07-14",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.SilverAge,Format.UltimatePitFight],
     legalHeroes: [Hero.Prism],
     name: "Luminaris, Celestial Fury",
     printings: [{
@@ -261294,7 +261294,7 @@ Once per turn, when you play an attack action card, remove a verse counter from 
     typeText: "Shadow Necromancer Hero - Young",
 
     
-    
+    bannedFormats: [Format.LivingLegend],
     createdExtras: ["corrupted-corpse"],
     
     
@@ -261393,7 +261393,7 @@ Whenever a zombie you control dies, banish it face-down and create a Corrupted C
     typeText: "Shadow Necromancer Hero",
 
     
-    
+    bannedFormats: [Format.SilverAge],
     createdExtras: ["corrupted-corpse"],
     
     
@@ -261955,7 +261955,7 @@ Damage that would be dealt by this can't be prevented.`,
     classes: [Class.Brute],
     defaultImage: "SKA002",
     firstReleaseDate: "2020-08-28",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
     legalHeroes: [Hero.Kayo,Hero.Levia,Hero.RKO,Hero.Rhinar,Hero.Tuffnut],
     name: "Mandible Claw",
     printings: [{
@@ -265480,7 +265480,7 @@ When this defends, become a random Agent of Chaos. If the attacking hero is **ma
     classes: [Class.Ninja],
     defaultImage: "TCC079",
     firstReleaseDate: "2023-09-29",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.UltimatePitFight],
     legalHeroes: [Hero.Benji,Hero.Cindra,Hero.Fai,Hero.Ira,Hero.Katsu,Hero.Taylor,Hero.Zen],
     name: "Mask of Three Tails",
     printings: [{
@@ -271364,7 +271364,7 @@ The first time you activate this each turn, gain 1 action point.`,
     classes: [Class.Guardian],
     defaultImage: "HVY050",
     firstReleaseDate: "2024-02-02",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
     legalHeroes: [Hero.Betsy,Hero.Bolfar,Hero.Bravo,Hero.Brevant,Hero.Brutus,Hero.Crix,Hero.Jarl,Hero.Kox,Hero.Lyath,Hero.Oldhim,Hero.Pleiades,Hero.Reya,Hero.Starvo,Hero.Terra,Hero.Valda,Hero.Victor,Hero.Yoji],
     name: "Miller's Grindstone",
     printings: [{
@@ -275409,7 +275409,7 @@ If this has 10 or more {p}, it gets **overpower**.`,
     classes: [Class.Runeblade],
     defaultImage: "AVS016",
     firstReleaseDate: "2020-03-27",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Aurora,Hero.Aurora2,Hero.Briar,Hero.Chane,Hero.Florian,Hero.Viserai,Hero.Viserai2,Hero.Vynnset],
     name: "Mordred Tide",
     printings: [{
@@ -278181,7 +278181,7 @@ When Nasreth hits a hero, banish a card from their soul. If a Light card is bani
     classes: [Class.Runeblade],
     defaultImage: "AVS002",
     firstReleaseDate: "2020-03-27",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
     legalHeroes: [Hero.Aurora,Hero.Aurora2,Hero.Briar,Hero.Chane,Hero.Florian,Hero.Viserai,Hero.Viserai2,Hero.Vynnset],
     name: "Nebula Blade",
     printings: [{
@@ -280357,7 +280357,7 @@ When this is destroyed, destroy all cards in your arsenal.
     classes: [Class.Generic],
     defaultImage: "SEA220",
     firstReleaseDate: "2025-06-06",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Arakni,Hero.Aurora,Hero.Aurora2,Hero.Azalea,Hero.Baalghor,Hero.Benji,Hero.Betsy,Hero.Blaze,Hero.Bolfar,Hero.Boltyn,Hero.Bravo,Hero.Brevant,Hero.Briar,Hero.Broscilio,Hero.Brutus,Hero.Chane,Hero.Cindra,Hero.Crackni,Hero.Crix,Hero.Dash,Hero.DataDoll,Hero.Dorinthea,Hero.Dromai,Hero.Emperor,Hero.Enigma,Hero.Fai,Hero.Fang,Hero.Florian,Hero.Frankie,Hero.Genis,Hero.GravyBones,Hero.Hala,Hero.Ira,Hero.Iyslander,Hero.Jarl,Hero.Kano,Hero.Kassai,Hero.Katsu,Hero.Kavdaen,Hero.Kayo,Hero.Killjoy,Hero.Kox,Hero.Levia,Hero.Lexi,Hero.Librarian,Hero.Lyath,Hero.Malice,Hero.Marlynn,Hero.Maxx,Hero.Melody,Hero.Mortimer,Hero.Nuu,Hero.Oldhim,Hero.Olympia,Hero.Oscilio,Hero.Pleiades,Hero.Prism,Hero.Puffin,Hero.RKO,Hero.Reya,Hero.Rhinar,Hero.Riptide,Hero.Ruudi,Hero.Scurv,Hero.Shiyana,Hero.Slippy,Hero.Squizzy,Hero.Starvo,Hero.Taipanis,Hero.Taylor,Hero.Teklovossen,Hero.Terra,Hero.Theryon,Hero.Tuffnut,Hero.Uzuri,Hero.Valda,Hero.Verdance,Hero.Victor,Hero.Viserai,Hero.Viserai2,Hero.Vynnset,Hero.Yoji,Hero.Yorick,Hero.Zane,Hero.Zen,Hero.Zyggy],
     name: "Nimby",
     printings: [{
@@ -280466,7 +280466,7 @@ When this is destroyed, destroy all cards in your arsenal.
     classes: [Class.Generic],
     defaultImage: "SEA221",
     firstReleaseDate: "2025-06-06",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Arakni,Hero.Aurora,Hero.Aurora2,Hero.Azalea,Hero.Baalghor,Hero.Benji,Hero.Betsy,Hero.Blaze,Hero.Bolfar,Hero.Boltyn,Hero.Bravo,Hero.Brevant,Hero.Briar,Hero.Broscilio,Hero.Brutus,Hero.Chane,Hero.Cindra,Hero.Crackni,Hero.Crix,Hero.Dash,Hero.DataDoll,Hero.Dorinthea,Hero.Dromai,Hero.Enigma,Hero.Fai,Hero.Fang,Hero.Florian,Hero.Frankie,Hero.Genis,Hero.GravyBones,Hero.Hala,Hero.Ira,Hero.Iyslander,Hero.Jarl,Hero.Kano,Hero.Kassai,Hero.Katsu,Hero.Kavdaen,Hero.Kayo,Hero.Killjoy,Hero.Kox,Hero.Levia,Hero.Lexi,Hero.Librarian,Hero.Lyath,Hero.Malice,Hero.Marlynn,Hero.Maxx,Hero.Melody,Hero.Mortimer,Hero.Nuu,Hero.Oldhim,Hero.Olympia,Hero.Oscilio,Hero.Pleiades,Hero.Prism,Hero.Puffin,Hero.RKO,Hero.Reya,Hero.Rhinar,Hero.Riptide,Hero.Ruudi,Hero.Scurv,Hero.Shiyana,Hero.Slippy,Hero.Squizzy,Hero.Starvo,Hero.Taipanis,Hero.Taylor,Hero.Teklovossen,Hero.Terra,Hero.Theryon,Hero.Tuffnut,Hero.Uzuri,Hero.Valda,Hero.Verdance,Hero.Victor,Hero.Viserai,Hero.Viserai2,Hero.Vynnset,Hero.Yoji,Hero.Yorick,Hero.Zane,Hero.Zen,Hero.Zyggy],
     name: "Nimby",
     printings: [{
@@ -280545,7 +280545,7 @@ When this is destroyed, destroy all cards in your arsenal.
     classes: [Class.Generic],
     defaultImage: "SEA222",
     firstReleaseDate: "2025-06-06",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Arakni,Hero.Aurora,Hero.Aurora2,Hero.Azalea,Hero.Baalghor,Hero.Benji,Hero.Betsy,Hero.Blaze,Hero.Bolfar,Hero.Boltyn,Hero.Bravo,Hero.Brevant,Hero.Briar,Hero.Broscilio,Hero.Brutus,Hero.Chane,Hero.Cindra,Hero.Crackni,Hero.Crix,Hero.Dash,Hero.DataDoll,Hero.Dorinthea,Hero.Dromai,Hero.Enigma,Hero.Fai,Hero.Fang,Hero.Florian,Hero.Frankie,Hero.Genis,Hero.GravyBones,Hero.Hala,Hero.Ira,Hero.Iyslander,Hero.Jarl,Hero.Kano,Hero.Kassai,Hero.Katsu,Hero.Kavdaen,Hero.Kayo,Hero.Killjoy,Hero.Kox,Hero.Levia,Hero.Lexi,Hero.Librarian,Hero.Lyath,Hero.Malice,Hero.Marlynn,Hero.Maxx,Hero.Melody,Hero.Mortimer,Hero.Nuu,Hero.Oldhim,Hero.Olympia,Hero.Oscilio,Hero.Pleiades,Hero.Prism,Hero.Puffin,Hero.RKO,Hero.Reya,Hero.Rhinar,Hero.Riptide,Hero.Ruudi,Hero.Scurv,Hero.Shiyana,Hero.Slippy,Hero.Squizzy,Hero.Starvo,Hero.Taipanis,Hero.Taylor,Hero.Teklovossen,Hero.Terra,Hero.Theryon,Hero.Tuffnut,Hero.Uzuri,Hero.Valda,Hero.Verdance,Hero.Victor,Hero.Viserai,Hero.Viserai2,Hero.Vynnset,Hero.Yoji,Hero.Yorick,Hero.Zane,Hero.Zen,Hero.Zyggy],
     name: "Nimby",
     printings: [{
@@ -286159,7 +286159,7 @@ When this defends, if it has 6 or more {d}, put it on the bottom of its owner's 
     classes: [Class.Generic],
     defaultImage: "SEA182",
     firstReleaseDate: "2025-06-06",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Arakni,Hero.Aurora,Hero.Aurora2,Hero.Azalea,Hero.Baalghor,Hero.Benji,Hero.Betsy,Hero.Blaze,Hero.Bolfar,Hero.Boltyn,Hero.Bravo,Hero.Brevant,Hero.Briar,Hero.Broscilio,Hero.Brutus,Hero.Chane,Hero.Cindra,Hero.Crackni,Hero.Crix,Hero.Dash,Hero.DataDoll,Hero.Dorinthea,Hero.Dromai,Hero.Emperor,Hero.Enigma,Hero.Fai,Hero.Fang,Hero.Florian,Hero.Frankie,Hero.Genis,Hero.GravyBones,Hero.Hala,Hero.Ira,Hero.Iyslander,Hero.Jarl,Hero.Kano,Hero.Kassai,Hero.Katsu,Hero.Kavdaen,Hero.Kayo,Hero.Killjoy,Hero.Kox,Hero.Levia,Hero.Lexi,Hero.Librarian,Hero.Lyath,Hero.Malice,Hero.Marlynn,Hero.Maxx,Hero.Melody,Hero.Mortimer,Hero.Nuu,Hero.Oldhim,Hero.Olympia,Hero.Oscilio,Hero.Pleiades,Hero.Prism,Hero.Puffin,Hero.RKO,Hero.Reya,Hero.Rhinar,Hero.Riptide,Hero.Ruudi,Hero.Scurv,Hero.Shiyana,Hero.Slippy,Hero.Squizzy,Hero.Starvo,Hero.Taipanis,Hero.Taylor,Hero.Teklovossen,Hero.Terra,Hero.Theryon,Hero.Tuffnut,Hero.Uzuri,Hero.Valda,Hero.Verdance,Hero.Victor,Hero.Viserai,Hero.Viserai2,Hero.Vynnset,Hero.Yoji,Hero.Yorick,Hero.Zane,Hero.Zen,Hero.Zyggy],
     name: "Old Knocker",
     printings: [{
@@ -289122,7 +289122,7 @@ If an aura you control was destroyed this turn, create a Ponder token.`,
     classes: [Class.Wizard],
     defaultImage: "ROS195",
     firstReleaseDate: "2024-09-20",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
     legalHeroes: [Hero.Blaze,Hero.Broscilio,Hero.Emperor,Hero.Iyslander,Hero.Kano,Hero.Oscilio,Hero.Verdance],
     name: "Open the Flood Gates",
     printings: [{
@@ -289203,7 +289203,7 @@ If an aura you control was destroyed this turn, create a Ponder token.`,
     classes: [Class.Wizard],
     defaultImage: "ROS196",
     firstReleaseDate: "2024-09-20",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
     legalHeroes: [Hero.Blaze,Hero.Broscilio,Hero.Iyslander,Hero.Kano,Hero.Oscilio,Hero.Verdance],
     name: "Open the Flood Gates",
     printings: [{
@@ -289284,7 +289284,7 @@ If an aura you control was destroyed this turn, create a Ponder token.`,
     classes: [Class.Wizard],
     defaultImage: "SBZ029",
     firstReleaseDate: "2024-09-20",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
     legalHeroes: [Hero.Blaze,Hero.Broscilio,Hero.Iyslander,Hero.Kano,Hero.Oscilio,Hero.Verdance],
     name: "Open the Flood Gates",
     printings: [{
@@ -289380,7 +289380,7 @@ If an aura you control was destroyed this turn, create a Ponder token.`,
     classes: [Class.NotClassed],
     defaultImage: "IAR166",
     firstReleaseDate: "2026-09-25",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Baalghor,Hero.Chane,Hero.Levia,Hero.Malice,Hero.Viserai2,Hero.Vynnset],
     name: "Open the Gate to i'Arathael",
     printings: [{
@@ -289430,7 +289430,7 @@ If an aura you control was destroyed this turn, create a Ponder token.`,
     typeText: "Shadow Action - Attack",
 
     
-    
+    bannedFormats: [Format.ClassicConstructed],
     cost: 0,createdExtras: ["gate-to-iarathael"],
     defense: 3,
     
@@ -289721,7 +289721,7 @@ Your next attack with **stealth** this turn gets +3{p}.
     classes: [Class.Assassin],
     defaultImage: "HNT027",
     firstReleaseDate: "2025-01-31",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
     legalHeroes: [Hero.Arakni,Hero.Crackni,Hero.Mortimer,Hero.Nuu,Hero.Slippy,Hero.Uzuri],
     name: "Orb-Weaver Spinneret",
     printings: [{
@@ -289804,7 +289804,7 @@ Your next attack with **stealth** this turn gets +2{p}.
     classes: [Class.Assassin],
     defaultImage: "HNT028",
     firstReleaseDate: "2025-01-31",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
     legalHeroes: [Hero.Arakni,Hero.Crackni,Hero.Mortimer,Hero.Nuu,Hero.Slippy,Hero.Uzuri],
     name: "Orb-Weaver Spinneret",
     printings: [{
@@ -290030,7 +290030,7 @@ When this hits a hero, the next time they defend with 1 or more non-attack actio
     classes: [Class.NotClassed],
     defaultImage: "MST080",
     firstReleaseDate: "2024-05-31",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Enigma,Hero.Nuu,Hero.Zen],
     name: "Orihon of Mystic Tenets",
     printings: [{
@@ -302717,7 +302717,7 @@ When this is destroyed, create a Spectral Shield token.`,
     classes: [Class.Illusionist],
     defaultImage: "EVO244",
     firstReleaseDate: "2023-10-06",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.UltimatePitFight],
     legalHeroes: [Hero.Dromai,Hero.Enigma,Hero.Prism,Hero.Zyggy],
     name: "Phantom Tidemaw",
     printings: [{
@@ -307844,7 +307844,7 @@ Whenever the crowd cheers you, create a Confidence token.`,
     classes: [Class.NotClassed],
     defaultImage: "U-ELE116",
     firstReleaseDate: "2021-09-24",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
     legalHeroes: [Hero.Briar,Hero.Florian,Hero.Jarl,Hero.Oldhim,Hero.Starvo,Hero.Taylor,Hero.Terra,Hero.Verdance],
     name: "Plume of Evergrowth",
     printings: [{
@@ -307983,7 +307983,7 @@ Whenever the crowd cheers you, create a Confidence token.`,
     classes: [Class.Generic],
     defaultImage: "U-ARC170",
     firstReleaseDate: "2020-03-27",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Arakni,Hero.Aurora,Hero.Aurora2,Hero.Azalea,Hero.Baalghor,Hero.Benji,Hero.Betsy,Hero.Blaze,Hero.Bolfar,Hero.Boltyn,Hero.Bravo,Hero.Brevant,Hero.Briar,Hero.Broscilio,Hero.Brutus,Hero.Chane,Hero.Cindra,Hero.Crackni,Hero.Crix,Hero.Dash,Hero.DataDoll,Hero.Dorinthea,Hero.Dromai,Hero.Emperor,Hero.Enigma,Hero.Fai,Hero.Fang,Hero.Florian,Hero.Frankie,Hero.Genis,Hero.GravyBones,Hero.Hala,Hero.Ira,Hero.Iyslander,Hero.Jarl,Hero.Kano,Hero.Kassai,Hero.Katsu,Hero.Kavdaen,Hero.Kayo,Hero.Killjoy,Hero.Kox,Hero.Levia,Hero.Lexi,Hero.Librarian,Hero.Lyath,Hero.Malice,Hero.Marlynn,Hero.Maxx,Hero.Melody,Hero.Mortimer,Hero.Nuu,Hero.Oldhim,Hero.Olympia,Hero.Oscilio,Hero.Pleiades,Hero.Prism,Hero.Puffin,Hero.RKO,Hero.Reya,Hero.Rhinar,Hero.Riptide,Hero.Ruudi,Hero.Scurv,Hero.Shiyana,Hero.Slippy,Hero.Squizzy,Hero.Starvo,Hero.Taipanis,Hero.Taylor,Hero.Teklovossen,Hero.Terra,Hero.Theryon,Hero.Tuffnut,Hero.Uzuri,Hero.Valda,Hero.Verdance,Hero.Victor,Hero.Viserai,Hero.Viserai2,Hero.Vynnset,Hero.Yoji,Hero.Yorick,Hero.Zane,Hero.Zen,Hero.Zyggy],
     name: "Plunder Run",
     printings: [{
@@ -308111,7 +308111,7 @@ If this was played from arsenal, the next attack action card you play this turn 
     classes: [Class.Generic],
     defaultImage: "U-ARC171",
     firstReleaseDate: "2020-03-27",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Arakni,Hero.Aurora,Hero.Aurora2,Hero.Azalea,Hero.Baalghor,Hero.Benji,Hero.Betsy,Hero.Blaze,Hero.Bolfar,Hero.Boltyn,Hero.Bravo,Hero.Brevant,Hero.Briar,Hero.Broscilio,Hero.Brutus,Hero.Chane,Hero.Cindra,Hero.Crackni,Hero.Crix,Hero.Dash,Hero.DataDoll,Hero.Dorinthea,Hero.Dromai,Hero.Enigma,Hero.Fai,Hero.Fang,Hero.Florian,Hero.Frankie,Hero.Genis,Hero.GravyBones,Hero.Hala,Hero.Ira,Hero.Iyslander,Hero.Jarl,Hero.Kano,Hero.Kassai,Hero.Katsu,Hero.Kavdaen,Hero.Kayo,Hero.Killjoy,Hero.Kox,Hero.Levia,Hero.Lexi,Hero.Librarian,Hero.Lyath,Hero.Malice,Hero.Marlynn,Hero.Maxx,Hero.Melody,Hero.Mortimer,Hero.Nuu,Hero.Oldhim,Hero.Olympia,Hero.Oscilio,Hero.Pleiades,Hero.Prism,Hero.Puffin,Hero.RKO,Hero.Reya,Hero.Rhinar,Hero.Riptide,Hero.Ruudi,Hero.Scurv,Hero.Shiyana,Hero.Slippy,Hero.Squizzy,Hero.Starvo,Hero.Taipanis,Hero.Taylor,Hero.Teklovossen,Hero.Terra,Hero.Theryon,Hero.Tuffnut,Hero.Uzuri,Hero.Valda,Hero.Verdance,Hero.Victor,Hero.Viserai,Hero.Viserai2,Hero.Vynnset,Hero.Yoji,Hero.Yorick,Hero.Zane,Hero.Zen,Hero.Zyggy],
     name: "Plunder Run",
     printings: [{
@@ -308239,7 +308239,7 @@ If this was played from arsenal, the next attack action card you play this turn 
     classes: [Class.Generic],
     defaultImage: "U-ARC172",
     firstReleaseDate: "2020-03-27",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Arakni,Hero.Aurora,Hero.Aurora2,Hero.Azalea,Hero.Baalghor,Hero.Benji,Hero.Betsy,Hero.Blaze,Hero.Bolfar,Hero.Boltyn,Hero.Bravo,Hero.Brevant,Hero.Briar,Hero.Broscilio,Hero.Brutus,Hero.Chane,Hero.Cindra,Hero.Crackni,Hero.Crix,Hero.Dash,Hero.DataDoll,Hero.Dorinthea,Hero.Dromai,Hero.Enigma,Hero.Fai,Hero.Fang,Hero.Florian,Hero.Frankie,Hero.Genis,Hero.GravyBones,Hero.Hala,Hero.Ira,Hero.Iyslander,Hero.Jarl,Hero.Kano,Hero.Kassai,Hero.Katsu,Hero.Kavdaen,Hero.Kayo,Hero.Killjoy,Hero.Kox,Hero.Levia,Hero.Lexi,Hero.Librarian,Hero.Lyath,Hero.Malice,Hero.Marlynn,Hero.Maxx,Hero.Melody,Hero.Mortimer,Hero.Nuu,Hero.Oldhim,Hero.Olympia,Hero.Oscilio,Hero.Pleiades,Hero.Prism,Hero.Puffin,Hero.RKO,Hero.Reya,Hero.Rhinar,Hero.Riptide,Hero.Ruudi,Hero.Scurv,Hero.Shiyana,Hero.Slippy,Hero.Squizzy,Hero.Starvo,Hero.Taipanis,Hero.Taylor,Hero.Teklovossen,Hero.Terra,Hero.Theryon,Hero.Tuffnut,Hero.Uzuri,Hero.Valda,Hero.Verdance,Hero.Victor,Hero.Viserai,Hero.Viserai2,Hero.Vynnset,Hero.Yoji,Hero.Yorick,Hero.Zane,Hero.Zen,Hero.Zyggy],
     name: "Plunder Run",
     printings: [{
@@ -317616,7 +317616,7 @@ Your next Brute attack this turn gets +3{p}.
     classes: [Class.Illusionist],
     defaultImage: "SAT001",
     firstReleaseDate: "2023-07-14",
-    legalFormats: [Format.Blitz,Format.Open,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Open,Format.UltimatePitFight],
     legalHeroes: [Hero.Prism],
     name: "Prism, Advent of Thrones",
     printings: [{
@@ -329297,7 +329297,7 @@ When there are no cards in your soul, destroy this.`,
     classes: [Class.Generic],
     defaultImage: "U-ELE233",
     firstReleaseDate: "2021-09-24",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Arakni,Hero.Aurora,Hero.Aurora2,Hero.Azalea,Hero.Baalghor,Hero.Benji,Hero.Betsy,Hero.Blaze,Hero.Bolfar,Hero.Boltyn,Hero.Bravo,Hero.Brevant,Hero.Briar,Hero.Broscilio,Hero.Brutus,Hero.Chane,Hero.Cindra,Hero.Crackni,Hero.Crix,Hero.Dash,Hero.DataDoll,Hero.Dorinthea,Hero.Dromai,Hero.Emperor,Hero.Enigma,Hero.Fai,Hero.Fang,Hero.Florian,Hero.Frankie,Hero.Genis,Hero.GravyBones,Hero.Hala,Hero.Ira,Hero.Iyslander,Hero.Jarl,Hero.Kano,Hero.Kassai,Hero.Katsu,Hero.Kavdaen,Hero.Kayo,Hero.Killjoy,Hero.Kox,Hero.Levia,Hero.Lexi,Hero.Librarian,Hero.Lyath,Hero.Malice,Hero.Marlynn,Hero.Maxx,Hero.Melody,Hero.Mortimer,Hero.Nuu,Hero.Oldhim,Hero.Olympia,Hero.Oscilio,Hero.Pleiades,Hero.Prism,Hero.Puffin,Hero.RKO,Hero.Reya,Hero.Rhinar,Hero.Riptide,Hero.Ruudi,Hero.Scurv,Hero.Shiyana,Hero.Slippy,Hero.Squizzy,Hero.Starvo,Hero.Taipanis,Hero.Taylor,Hero.Teklovossen,Hero.Terra,Hero.Theryon,Hero.Tuffnut,Hero.Uzuri,Hero.Valda,Hero.Verdance,Hero.Victor,Hero.Viserai,Hero.Viserai2,Hero.Vynnset,Hero.Yoji,Hero.Yorick,Hero.Zane,Hero.Zen,Hero.Zyggy],
     name: "Ragamuffin's Hat",
     printings: [{
@@ -335891,7 +335891,7 @@ The next attack you **boost** this turn gets +2{p}.
     typeText: "Shadow Equipment - Arms",
 
     
-    
+    bannedFormats: [Format.SilverAge],
     
     defense: 2,
     
@@ -336993,7 +336993,7 @@ If you would roll 1 or more dice this turn, instead roll that many dice plus 1 a
     classes: [Class.Illusionist],
     defaultImage: "DTD216",
     firstReleaseDate: "2023-07-14",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.UltimatePitFight],
     legalHeroes: [Hero.Dromai,Hero.Enigma,Hero.Prism,Hero.Zyggy],
     name: "Reality Refractor",
     printings: [{
@@ -337390,7 +337390,7 @@ If you would roll 1 or more dice this turn, instead roll that many dice plus 1 a
     classes: [Class.Runeblade],
     defaultImage: "SVI002",
     firstReleaseDate: "2020-08-28",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.UltimatePitFight],
     legalHeroes: [Hero.Aurora,Hero.Aurora2,Hero.Briar,Hero.Chane,Hero.Florian,Hero.Viserai,Hero.Viserai2,Hero.Vynnset],
     name: "Reaping Blade",
     printings: [{
@@ -343027,7 +343027,7 @@ If this wasn't played from hand or arsenal, it gets +2{p}.`,
     classes: [Class.Generic],
     defaultImage: "U-WTR163",
     firstReleaseDate: "2019-10-11",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Arakni,Hero.Aurora,Hero.Aurora2,Hero.Azalea,Hero.Baalghor,Hero.Benji,Hero.Betsy,Hero.Blaze,Hero.Bolfar,Hero.Boltyn,Hero.Bravo,Hero.Brevant,Hero.Briar,Hero.Broscilio,Hero.Brutus,Hero.Chane,Hero.Cindra,Hero.Crackni,Hero.Crix,Hero.Dash,Hero.DataDoll,Hero.Dorinthea,Hero.Dromai,Hero.Enigma,Hero.Fai,Hero.Fang,Hero.Florian,Hero.Frankie,Hero.Genis,Hero.GravyBones,Hero.Hala,Hero.Ira,Hero.Iyslander,Hero.Jarl,Hero.Kano,Hero.Kassai,Hero.Katsu,Hero.Kavdaen,Hero.Kayo,Hero.Killjoy,Hero.Kox,Hero.Levia,Hero.Lexi,Hero.Librarian,Hero.Lyath,Hero.Malice,Hero.Marlynn,Hero.Maxx,Hero.Melody,Hero.Mortimer,Hero.Nuu,Hero.Oldhim,Hero.Olympia,Hero.Oscilio,Hero.Pleiades,Hero.Prism,Hero.Puffin,Hero.RKO,Hero.Reya,Hero.Rhinar,Hero.Riptide,Hero.Ruudi,Hero.Scurv,Hero.Shiyana,Hero.Slippy,Hero.Squizzy,Hero.Starvo,Hero.Taipanis,Hero.Taylor,Hero.Teklovossen,Hero.Terra,Hero.Theryon,Hero.Tuffnut,Hero.Uzuri,Hero.Valda,Hero.Verdance,Hero.Victor,Hero.Viserai,Hero.Viserai2,Hero.Vynnset,Hero.Yoji,Hero.Yorick,Hero.Zane,Hero.Zen,Hero.Zyggy],
     name: "Remembrance",
     printings: [{
@@ -344464,7 +344464,7 @@ At the start of your turn, destroy this and draw a card.`,
     typeText: "Shadow Necromancer Action - Zombie Ally",
 
     
-    
+    bannedFormats: [Format.SilverAge],
     cost: 0,
     
     
@@ -356961,7 +356961,7 @@ Once per turn, when you discard a card with 6 or more {p}, this gets +1{p} until
     classes: [Class.Runeblade],
     defaultImage: "ELE222",
     firstReleaseDate: "2021-09-24",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.GoldenAge,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Aurora,Hero.Aurora2,Hero.Briar,Hero.Chane,Hero.Florian,Hero.Viserai,Hero.Viserai2,Hero.Vynnset],
     name: "Rosetta Thorn",
     printings: [{
@@ -357599,7 +357599,7 @@ If you have **boosted** this turn, put Rotary Ram on the bottom of your deck.
     classes: [Class.Runeblade],
     defaultImage: "ROS003",
     firstReleaseDate: "2024-09-20",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
     legalHeroes: [Hero.Briar,Hero.Florian],
     name: "Rotwood Reaper",
     printings: [{
@@ -363175,7 +363175,7 @@ If an attack action card was pitched to play this, the next Runeblade attack act
     classes: [Class.Runeblade],
     defaultImage: "IAR149",
     firstReleaseDate: "2026-07-06",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Aurora,Hero.Aurora2,Hero.Briar,Hero.Chane,Hero.Florian,Hero.Viserai,Hero.Viserai2,Hero.Vynnset],
     name: "Runic Reaving",
     printings: [{
@@ -363225,7 +363225,7 @@ If an attack action card was pitched to play this, the next Runeblade attack act
     typeText: "Runeblade Action - Attack",
 
     
-    
+    bannedFormats: [Format.SilverAge],
     cost: 0,createdExtras: ["runechant"],
     defense: 2,
     
@@ -363706,7 +363706,7 @@ The next Runeblade attack action card you play this turn gets +3{p}.
     typeText: "Illusionist / Wizard Action - Attack",
 
     
-    
+    bannedFormats: [Format.SilverAge],
     cost: 0,
     defense: 2,
     
@@ -392875,7 +392875,7 @@ At the beginning of your action phase, destroy this.`,
     classes: [Class.Generic],
     defaultImage: "HNT231",
     firstReleaseDate: "2019-10-11",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Arakni,Hero.Aurora,Hero.Aurora2,Hero.Azalea,Hero.Baalghor,Hero.Benji,Hero.Betsy,Hero.Blaze,Hero.Bolfar,Hero.Boltyn,Hero.Bravo,Hero.Brevant,Hero.Briar,Hero.Broscilio,Hero.Brutus,Hero.Chane,Hero.Cindra,Hero.Crackni,Hero.Crix,Hero.Dash,Hero.DataDoll,Hero.Dorinthea,Hero.Dromai,Hero.Emperor,Hero.Enigma,Hero.Fai,Hero.Fang,Hero.Florian,Hero.Frankie,Hero.Genis,Hero.GravyBones,Hero.Hala,Hero.Ira,Hero.Iyslander,Hero.Jarl,Hero.Kano,Hero.Kassai,Hero.Katsu,Hero.Kavdaen,Hero.Kayo,Hero.Killjoy,Hero.Kox,Hero.Levia,Hero.Lexi,Hero.Librarian,Hero.Lyath,Hero.Malice,Hero.Marlynn,Hero.Maxx,Hero.Melody,Hero.Mortimer,Hero.Nuu,Hero.Oldhim,Hero.Olympia,Hero.Oscilio,Hero.Pleiades,Hero.Prism,Hero.Puffin,Hero.RKO,Hero.Reya,Hero.Rhinar,Hero.Riptide,Hero.Ruudi,Hero.Scurv,Hero.Shiyana,Hero.Slippy,Hero.Squizzy,Hero.Starvo,Hero.Taipanis,Hero.Taylor,Hero.Teklovossen,Hero.Terra,Hero.Theryon,Hero.Tuffnut,Hero.Uzuri,Hero.Valda,Hero.Verdance,Hero.Victor,Hero.Viserai,Hero.Viserai2,Hero.Vynnset,Hero.Yoji,Hero.Yorick,Hero.Zane,Hero.Zen,Hero.Zyggy],
     name: "Sigil of Solace",
     printings: [{
@@ -393089,7 +393089,7 @@ At the beginning of your action phase, destroy this.`,
     classes: [Class.Generic],
     defaultImage: "U-WTR174",
     firstReleaseDate: "2019-10-11",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Arakni,Hero.Aurora,Hero.Aurora2,Hero.Azalea,Hero.Baalghor,Hero.Benji,Hero.Betsy,Hero.Blaze,Hero.Bolfar,Hero.Boltyn,Hero.Bravo,Hero.Brevant,Hero.Briar,Hero.Broscilio,Hero.Brutus,Hero.Chane,Hero.Cindra,Hero.Crackni,Hero.Crix,Hero.Dash,Hero.DataDoll,Hero.Dorinthea,Hero.Dromai,Hero.Enigma,Hero.Fai,Hero.Fang,Hero.Florian,Hero.Frankie,Hero.Genis,Hero.GravyBones,Hero.Hala,Hero.Ira,Hero.Iyslander,Hero.Jarl,Hero.Kano,Hero.Kassai,Hero.Katsu,Hero.Kavdaen,Hero.Kayo,Hero.Killjoy,Hero.Kox,Hero.Levia,Hero.Lexi,Hero.Librarian,Hero.Lyath,Hero.Malice,Hero.Marlynn,Hero.Maxx,Hero.Melody,Hero.Mortimer,Hero.Nuu,Hero.Oldhim,Hero.Olympia,Hero.Oscilio,Hero.Pleiades,Hero.Prism,Hero.Puffin,Hero.RKO,Hero.Reya,Hero.Rhinar,Hero.Riptide,Hero.Ruudi,Hero.Scurv,Hero.Shiyana,Hero.Slippy,Hero.Squizzy,Hero.Starvo,Hero.Taipanis,Hero.Taylor,Hero.Teklovossen,Hero.Terra,Hero.Theryon,Hero.Tuffnut,Hero.Uzuri,Hero.Valda,Hero.Verdance,Hero.Victor,Hero.Viserai,Hero.Viserai2,Hero.Vynnset,Hero.Yoji,Hero.Yorick,Hero.Zane,Hero.Zen,Hero.Zyggy],
     name: "Sigil of Solace",
     printings: [{
@@ -393213,7 +393213,7 @@ At the beginning of your action phase, destroy this.`,
     classes: [Class.Generic],
     defaultImage: "DVR025",
     firstReleaseDate: "2019-10-11",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Arakni,Hero.Aurora,Hero.Aurora2,Hero.Azalea,Hero.Baalghor,Hero.Benji,Hero.Betsy,Hero.Blaze,Hero.Bolfar,Hero.Boltyn,Hero.Bravo,Hero.Brevant,Hero.Briar,Hero.Broscilio,Hero.Brutus,Hero.Chane,Hero.Cindra,Hero.Crackni,Hero.Crix,Hero.Dash,Hero.DataDoll,Hero.Dorinthea,Hero.Dromai,Hero.Enigma,Hero.Fai,Hero.Fang,Hero.Florian,Hero.Frankie,Hero.Genis,Hero.GravyBones,Hero.Hala,Hero.Ira,Hero.Iyslander,Hero.Jarl,Hero.Kano,Hero.Kassai,Hero.Katsu,Hero.Kavdaen,Hero.Kayo,Hero.Killjoy,Hero.Kox,Hero.Levia,Hero.Lexi,Hero.Librarian,Hero.Lyath,Hero.Malice,Hero.Marlynn,Hero.Maxx,Hero.Melody,Hero.Mortimer,Hero.Nuu,Hero.Oldhim,Hero.Olympia,Hero.Oscilio,Hero.Pleiades,Hero.Prism,Hero.Puffin,Hero.RKO,Hero.Reya,Hero.Rhinar,Hero.Riptide,Hero.Ruudi,Hero.Scurv,Hero.Shiyana,Hero.Slippy,Hero.Squizzy,Hero.Starvo,Hero.Taipanis,Hero.Taylor,Hero.Teklovossen,Hero.Terra,Hero.Theryon,Hero.Tuffnut,Hero.Uzuri,Hero.Valda,Hero.Verdance,Hero.Victor,Hero.Viserai,Hero.Viserai2,Hero.Vynnset,Hero.Yoji,Hero.Yorick,Hero.Zane,Hero.Zen,Hero.Zyggy],
     name: "Sigil of Solace",
     printings: [{
@@ -394250,7 +394250,7 @@ When this leaves the arena, reveal the top card of your deck. If it's an attack 
     typeText: "Wizard Action - Aura",
 
     
-    
+    bannedFormats: [Format.SilverAge],
     cost: 0,createdExtras: ["ponder"],
     defense: 3,
     
@@ -397704,7 +397704,7 @@ Target weapon attack gets +1{p}.
     classes: [Class.Generic],
     defaultImage: "ASR018",
     firstReleaseDate: "2019-10-11",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Arakni,Hero.Aurora,Hero.Aurora2,Hero.Azalea,Hero.Baalghor,Hero.Benji,Hero.Betsy,Hero.Blaze,Hero.Bolfar,Hero.Boltyn,Hero.Bravo,Hero.Brevant,Hero.Briar,Hero.Broscilio,Hero.Brutus,Hero.Chane,Hero.Cindra,Hero.Crackni,Hero.Crix,Hero.Dash,Hero.DataDoll,Hero.Dorinthea,Hero.Dromai,Hero.Emperor,Hero.Enigma,Hero.Fai,Hero.Fang,Hero.Florian,Hero.Frankie,Hero.Genis,Hero.GravyBones,Hero.Hala,Hero.Ira,Hero.Iyslander,Hero.Jarl,Hero.Kano,Hero.Kassai,Hero.Katsu,Hero.Kavdaen,Hero.Kayo,Hero.Killjoy,Hero.Kox,Hero.Levia,Hero.Lexi,Hero.Librarian,Hero.Lyath,Hero.Malice,Hero.Marlynn,Hero.Maxx,Hero.Melody,Hero.Mortimer,Hero.Nuu,Hero.Oldhim,Hero.Olympia,Hero.Oscilio,Hero.Pleiades,Hero.Prism,Hero.Puffin,Hero.RKO,Hero.Reya,Hero.Rhinar,Hero.Riptide,Hero.Ruudi,Hero.Scurv,Hero.Shiyana,Hero.Slippy,Hero.Squizzy,Hero.Starvo,Hero.Taipanis,Hero.Taylor,Hero.Teklovossen,Hero.Terra,Hero.Theryon,Hero.Tuffnut,Hero.Uzuri,Hero.Valda,Hero.Verdance,Hero.Victor,Hero.Viserai,Hero.Viserai2,Hero.Vynnset,Hero.Yoji,Hero.Yorick,Hero.Zane,Hero.Zen,Hero.Zyggy],
     name: "Sink Below",
     printings: [{
@@ -397945,7 +397945,7 @@ Target weapon attack gets +1{p}.
     classes: [Class.Generic],
     defaultImage: "U-WTR216",
     firstReleaseDate: "2019-10-11",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Arakni,Hero.Aurora,Hero.Aurora2,Hero.Azalea,Hero.Baalghor,Hero.Benji,Hero.Betsy,Hero.Blaze,Hero.Bolfar,Hero.Boltyn,Hero.Bravo,Hero.Brevant,Hero.Briar,Hero.Broscilio,Hero.Brutus,Hero.Chane,Hero.Cindra,Hero.Crackni,Hero.Crix,Hero.Dash,Hero.DataDoll,Hero.Dorinthea,Hero.Dromai,Hero.Enigma,Hero.Fai,Hero.Fang,Hero.Florian,Hero.Frankie,Hero.Genis,Hero.GravyBones,Hero.Hala,Hero.Ira,Hero.Iyslander,Hero.Jarl,Hero.Kano,Hero.Kassai,Hero.Katsu,Hero.Kavdaen,Hero.Kayo,Hero.Killjoy,Hero.Kox,Hero.Levia,Hero.Lexi,Hero.Librarian,Hero.Lyath,Hero.Malice,Hero.Marlynn,Hero.Maxx,Hero.Melody,Hero.Mortimer,Hero.Nuu,Hero.Oldhim,Hero.Olympia,Hero.Oscilio,Hero.Pleiades,Hero.Prism,Hero.Puffin,Hero.RKO,Hero.Reya,Hero.Rhinar,Hero.Riptide,Hero.Ruudi,Hero.Scurv,Hero.Shiyana,Hero.Slippy,Hero.Squizzy,Hero.Starvo,Hero.Taipanis,Hero.Taylor,Hero.Teklovossen,Hero.Terra,Hero.Theryon,Hero.Tuffnut,Hero.Uzuri,Hero.Valda,Hero.Verdance,Hero.Victor,Hero.Viserai,Hero.Viserai2,Hero.Vynnset,Hero.Yoji,Hero.Yorick,Hero.Zane,Hero.Zen,Hero.Zyggy],
     name: "Sink Below",
     printings: [{
@@ -398069,7 +398069,7 @@ Target weapon attack gets +1{p}.
     classes: [Class.Generic],
     defaultImage: "U-WTR217",
     firstReleaseDate: "2019-10-11",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Arakni,Hero.Aurora,Hero.Aurora2,Hero.Azalea,Hero.Baalghor,Hero.Benji,Hero.Betsy,Hero.Blaze,Hero.Bolfar,Hero.Boltyn,Hero.Bravo,Hero.Brevant,Hero.Briar,Hero.Broscilio,Hero.Brutus,Hero.Chane,Hero.Cindra,Hero.Crackni,Hero.Crix,Hero.Dash,Hero.DataDoll,Hero.Dorinthea,Hero.Dromai,Hero.Enigma,Hero.Fai,Hero.Fang,Hero.Florian,Hero.Frankie,Hero.Genis,Hero.GravyBones,Hero.Hala,Hero.Ira,Hero.Iyslander,Hero.Jarl,Hero.Kano,Hero.Kassai,Hero.Katsu,Hero.Kavdaen,Hero.Kayo,Hero.Killjoy,Hero.Kox,Hero.Levia,Hero.Lexi,Hero.Librarian,Hero.Lyath,Hero.Malice,Hero.Marlynn,Hero.Maxx,Hero.Melody,Hero.Mortimer,Hero.Nuu,Hero.Oldhim,Hero.Olympia,Hero.Oscilio,Hero.Pleiades,Hero.Prism,Hero.Puffin,Hero.RKO,Hero.Reya,Hero.Rhinar,Hero.Riptide,Hero.Ruudi,Hero.Scurv,Hero.Shiyana,Hero.Slippy,Hero.Squizzy,Hero.Starvo,Hero.Taipanis,Hero.Taylor,Hero.Teklovossen,Hero.Terra,Hero.Theryon,Hero.Tuffnut,Hero.Uzuri,Hero.Valda,Hero.Verdance,Hero.Victor,Hero.Viserai,Hero.Viserai2,Hero.Vynnset,Hero.Yoji,Hero.Yorick,Hero.Zane,Hero.Zen,Hero.Zyggy],
     name: "Sink Below",
     printings: [{
@@ -398312,7 +398312,7 @@ Target weapon attack gets +1{p}.
     typeText: "Shadow Runeblade Action - Attack",
 
     
-    
+    bannedFormats: [Format.SilverAge],
     cost: 0,
     defense: 3,
     
@@ -398432,7 +398432,7 @@ If this was played from your banished zone, it gets "When this attacks, you may 
     classes: [Class.Generic],
     defaultImage: "SEA226",
     firstReleaseDate: "2025-06-06",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Arakni,Hero.Aurora,Hero.Aurora2,Hero.Azalea,Hero.Baalghor,Hero.Benji,Hero.Betsy,Hero.Blaze,Hero.Bolfar,Hero.Boltyn,Hero.Bravo,Hero.Brevant,Hero.Briar,Hero.Broscilio,Hero.Brutus,Hero.Chane,Hero.Cindra,Hero.Crackni,Hero.Crix,Hero.Dash,Hero.DataDoll,Hero.Dorinthea,Hero.Dromai,Hero.Emperor,Hero.Enigma,Hero.Fai,Hero.Fang,Hero.Florian,Hero.Frankie,Hero.Genis,Hero.GravyBones,Hero.Hala,Hero.Ira,Hero.Iyslander,Hero.Jarl,Hero.Kano,Hero.Kassai,Hero.Katsu,Hero.Kavdaen,Hero.Kayo,Hero.Killjoy,Hero.Kox,Hero.Levia,Hero.Lexi,Hero.Librarian,Hero.Lyath,Hero.Malice,Hero.Marlynn,Hero.Maxx,Hero.Melody,Hero.Mortimer,Hero.Nuu,Hero.Oldhim,Hero.Olympia,Hero.Oscilio,Hero.Pleiades,Hero.Prism,Hero.Puffin,Hero.RKO,Hero.Reya,Hero.Rhinar,Hero.Riptide,Hero.Ruudi,Hero.Scurv,Hero.Shiyana,Hero.Slippy,Hero.Squizzy,Hero.Starvo,Hero.Taipanis,Hero.Taylor,Hero.Teklovossen,Hero.Terra,Hero.Theryon,Hero.Tuffnut,Hero.Uzuri,Hero.Valda,Hero.Verdance,Hero.Victor,Hero.Viserai,Hero.Viserai2,Hero.Vynnset,Hero.Yoji,Hero.Yorick,Hero.Zane,Hero.Zen,Hero.Zyggy],
     name: "Sirens of Safe Harbor",
     printings: [{
@@ -398541,7 +398541,7 @@ If this was played from your banished zone, it gets "When this attacks, you may 
     classes: [Class.Generic],
     defaultImage: "SEA227",
     firstReleaseDate: "2025-06-06",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Arakni,Hero.Aurora,Hero.Aurora2,Hero.Azalea,Hero.Baalghor,Hero.Benji,Hero.Betsy,Hero.Blaze,Hero.Bolfar,Hero.Boltyn,Hero.Bravo,Hero.Brevant,Hero.Briar,Hero.Broscilio,Hero.Brutus,Hero.Chane,Hero.Cindra,Hero.Crackni,Hero.Crix,Hero.Dash,Hero.DataDoll,Hero.Dorinthea,Hero.Dromai,Hero.Enigma,Hero.Fai,Hero.Fang,Hero.Florian,Hero.Frankie,Hero.Genis,Hero.GravyBones,Hero.Hala,Hero.Ira,Hero.Iyslander,Hero.Jarl,Hero.Kano,Hero.Kassai,Hero.Katsu,Hero.Kavdaen,Hero.Kayo,Hero.Killjoy,Hero.Kox,Hero.Levia,Hero.Lexi,Hero.Librarian,Hero.Lyath,Hero.Malice,Hero.Marlynn,Hero.Maxx,Hero.Melody,Hero.Mortimer,Hero.Nuu,Hero.Oldhim,Hero.Olympia,Hero.Oscilio,Hero.Pleiades,Hero.Prism,Hero.Puffin,Hero.RKO,Hero.Reya,Hero.Rhinar,Hero.Riptide,Hero.Ruudi,Hero.Scurv,Hero.Shiyana,Hero.Slippy,Hero.Squizzy,Hero.Starvo,Hero.Taipanis,Hero.Taylor,Hero.Teklovossen,Hero.Terra,Hero.Theryon,Hero.Tuffnut,Hero.Uzuri,Hero.Valda,Hero.Verdance,Hero.Victor,Hero.Viserai,Hero.Viserai2,Hero.Vynnset,Hero.Yoji,Hero.Yorick,Hero.Zane,Hero.Zen,Hero.Zyggy],
     name: "Sirens of Safe Harbor",
     printings: [{
@@ -398620,7 +398620,7 @@ If this was played from your banished zone, it gets "When this attacks, you may 
     classes: [Class.Generic],
     defaultImage: "SEA228",
     firstReleaseDate: "2025-06-06",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Arakni,Hero.Aurora,Hero.Aurora2,Hero.Azalea,Hero.Baalghor,Hero.Benji,Hero.Betsy,Hero.Blaze,Hero.Bolfar,Hero.Boltyn,Hero.Bravo,Hero.Brevant,Hero.Briar,Hero.Broscilio,Hero.Brutus,Hero.Chane,Hero.Cindra,Hero.Crackni,Hero.Crix,Hero.Dash,Hero.DataDoll,Hero.Dorinthea,Hero.Dromai,Hero.Enigma,Hero.Fai,Hero.Fang,Hero.Florian,Hero.Frankie,Hero.Genis,Hero.GravyBones,Hero.Hala,Hero.Ira,Hero.Iyslander,Hero.Jarl,Hero.Kano,Hero.Kassai,Hero.Katsu,Hero.Kavdaen,Hero.Kayo,Hero.Killjoy,Hero.Kox,Hero.Levia,Hero.Lexi,Hero.Librarian,Hero.Lyath,Hero.Malice,Hero.Marlynn,Hero.Maxx,Hero.Melody,Hero.Mortimer,Hero.Nuu,Hero.Oldhim,Hero.Olympia,Hero.Oscilio,Hero.Pleiades,Hero.Prism,Hero.Puffin,Hero.RKO,Hero.Reya,Hero.Rhinar,Hero.Riptide,Hero.Ruudi,Hero.Scurv,Hero.Shiyana,Hero.Slippy,Hero.Squizzy,Hero.Starvo,Hero.Taipanis,Hero.Taylor,Hero.Teklovossen,Hero.Terra,Hero.Theryon,Hero.Tuffnut,Hero.Uzuri,Hero.Valda,Hero.Verdance,Hero.Victor,Hero.Viserai,Hero.Viserai2,Hero.Vynnset,Hero.Yoji,Hero.Yorick,Hero.Zane,Hero.Zen,Hero.Zyggy],
     name: "Sirens of Safe Harbor",
     printings: [{
@@ -401026,7 +401026,7 @@ Whenever you roll a 1 on a die, destroy this.
     classes: [Class.Runeblade],
     defaultImage: "AST023",
     firstReleaseDate: "2025-03-14",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.LivingLegend,Format.Open,Format.UltimatePitFight],
     legalHeroes: [Hero.Aurora,Hero.Aurora2,Hero.Briar],
     name: "Skyward Serenade",
     printings: [{
@@ -406765,7 +406765,7 @@ If you've played another Wizard non-attack action card this turn, you may play t
     classes: [Class.Generic],
     defaultImage: "ASR006",
     firstReleaseDate: "2019-10-11",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Arakni,Hero.Aurora,Hero.Aurora2,Hero.Azalea,Hero.Baalghor,Hero.Benji,Hero.Betsy,Hero.Blaze,Hero.Bolfar,Hero.Boltyn,Hero.Bravo,Hero.Brevant,Hero.Briar,Hero.Broscilio,Hero.Brutus,Hero.Chane,Hero.Cindra,Hero.Crackni,Hero.Crix,Hero.Dash,Hero.DataDoll,Hero.Dorinthea,Hero.Dromai,Hero.Emperor,Hero.Enigma,Hero.Fai,Hero.Fang,Hero.Florian,Hero.Frankie,Hero.Genis,Hero.GravyBones,Hero.Hala,Hero.Ira,Hero.Iyslander,Hero.Jarl,Hero.Kano,Hero.Kassai,Hero.Katsu,Hero.Kavdaen,Hero.Kayo,Hero.Killjoy,Hero.Kox,Hero.Levia,Hero.Lexi,Hero.Librarian,Hero.Lyath,Hero.Malice,Hero.Marlynn,Hero.Maxx,Hero.Melody,Hero.Mortimer,Hero.Nuu,Hero.Oldhim,Hero.Olympia,Hero.Oscilio,Hero.Pleiades,Hero.Prism,Hero.Puffin,Hero.RKO,Hero.Reya,Hero.Rhinar,Hero.Riptide,Hero.Ruudi,Hero.Scurv,Hero.Shiyana,Hero.Slippy,Hero.Squizzy,Hero.Starvo,Hero.Taipanis,Hero.Taylor,Hero.Teklovossen,Hero.Terra,Hero.Theryon,Hero.Tuffnut,Hero.Uzuri,Hero.Valda,Hero.Verdance,Hero.Victor,Hero.Viserai,Hero.Viserai2,Hero.Vynnset,Hero.Yoji,Hero.Yorick,Hero.Zane,Hero.Zen,Hero.Zyggy],
     name: "Snapdragon Scalers",
     printings: [{
@@ -409306,7 +409306,7 @@ For each non-attack action card revealed this way, put an attack action card rev
     typeText: "Runeblade Action",
 
     
-    
+    bannedFormats: [Format.SilverAge],
     createdExtras: ["runechant"],
     defense: 3,
     
@@ -411269,7 +411269,7 @@ When this hits a hero, banish all cards in their soul. They lose {h} equal to th
     typeText: "Shadow Resource - Gem",
 
     
-    
+    bannedFormats: [Format.SilverAge],
     
     
     
@@ -422457,7 +422457,7 @@ At the start of your turn, destroy this, draw a card, then put a card from your 
     classes: [Class.Wizard],
     defaultImage: "ROS015",
     firstReleaseDate: "2024-09-20",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
     legalHeroes: [Hero.Verdance],
     name: "Staff of Verdant Shoots",
     printings: [{
@@ -423607,7 +423607,7 @@ If you control a Vigor token, this gets +1{d}.
     classes: [Class.Runeblade],
     defaultImage: "SBA003",
     firstReleaseDate: "2024-08-01",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
     legalHeroes: [Hero.Aurora,Hero.Aurora2,Hero.Briar],
     name: "Star Fall",
     printings: [{
@@ -428941,7 +428941,7 @@ If this was **fused**, it gets +2{p}.`,
     typeText: "Ninja Action - Attack",
 
     
-    
+    bannedFormats: [Format.SilverAge],
     cost: 1,
     defense: 3,
     
@@ -430063,7 +430063,7 @@ At the beginning of your action phase, destroy this.`,
     classes: [Class.Illusionist],
     defaultImage: "UPR003",
     firstReleaseDate: "2022-06-24",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
     legalHeroes: [Hero.Dromai],
     name: "Storm of Sandikai",
     printings: [{
@@ -433557,7 +433557,7 @@ At the beginning of your action phase, destroy this, then your next attack this 
     classes: [Class.Generic],
     defaultImage: "U-MON239",
     firstReleaseDate: "2021-05-07",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Arakni,Hero.Aurora,Hero.Aurora2,Hero.Azalea,Hero.Baalghor,Hero.Benji,Hero.Betsy,Hero.Blaze,Hero.Bolfar,Hero.Boltyn,Hero.Bravo,Hero.Brevant,Hero.Briar,Hero.Broscilio,Hero.Brutus,Hero.Chane,Hero.Cindra,Hero.Crackni,Hero.Crix,Hero.Dash,Hero.DataDoll,Hero.Dorinthea,Hero.Dromai,Hero.Emperor,Hero.Enigma,Hero.Fai,Hero.Fang,Hero.Florian,Hero.Frankie,Hero.Genis,Hero.GravyBones,Hero.Hala,Hero.Ira,Hero.Iyslander,Hero.Jarl,Hero.Kano,Hero.Kassai,Hero.Katsu,Hero.Kavdaen,Hero.Kayo,Hero.Killjoy,Hero.Kox,Hero.Levia,Hero.Lexi,Hero.Librarian,Hero.Lyath,Hero.Malice,Hero.Marlynn,Hero.Maxx,Hero.Melody,Hero.Mortimer,Hero.Nuu,Hero.Oldhim,Hero.Olympia,Hero.Oscilio,Hero.Pleiades,Hero.Prism,Hero.Puffin,Hero.RKO,Hero.Reya,Hero.Rhinar,Hero.Riptide,Hero.Ruudi,Hero.Scurv,Hero.Shiyana,Hero.Slippy,Hero.Squizzy,Hero.Starvo,Hero.Taipanis,Hero.Taylor,Hero.Teklovossen,Hero.Terra,Hero.Theryon,Hero.Tuffnut,Hero.Uzuri,Hero.Valda,Hero.Verdance,Hero.Victor,Hero.Viserai,Hero.Viserai2,Hero.Vynnset,Hero.Yoji,Hero.Yorick,Hero.Zane,Hero.Zen,Hero.Zyggy],
     name: "Stubby Hammerers",
     printings: [{
@@ -447905,7 +447905,7 @@ At the beginning of your action phase, remove a steam counter from this and gain
     classes: [Class.Mechanologist],
     defaultImage: "CRU100",
     firstReleaseDate: "2020-03-27",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
     legalHeroes: [Hero.Dash,Hero.DataDoll,Hero.Maxx,Hero.Puffin,Hero.Teklovossen],
     name: "Teklo Plasma Pistol",
     printings: [{
@@ -457448,7 +457448,7 @@ If you've pitched a blue card this turn, create a Crouching Tiger in your hand.
     classes: [Class.Ninja],
     defaultImage: "MST159",
     firstReleaseDate: "2024-05-31",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
     legalHeroes: [Hero.Benji,Hero.Cindra,Hero.Fai,Hero.Ira,Hero.Katsu,Hero.Zen],
     name: "Tiger Taming Khakkara",
     printings: [{
@@ -460030,7 +460030,7 @@ The first time you would be dealt damage each turn, prevent 1 of that damage.`,
     classes: [Class.Wizard],
     defaultImage: "U-ARC122",
     firstReleaseDate: "2020-03-27",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Blaze,Hero.Broscilio,Hero.Emperor,Hero.Iyslander,Hero.Kano,Hero.Librarian,Hero.Oscilio,Hero.Verdance],
     name: "Tome of Aetherwind",
     printings: [{
@@ -460158,7 +460158,7 @@ The first time you would be dealt damage each turn, prevent 1 of that damage.`,
     classes: [Class.NotClassed],
     defaultImage: "U-MON065",
     firstReleaseDate: "2021-05-07",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Boltyn,Hero.Librarian,Hero.Prism,Hero.Theryon],
     name: "Tome of Divinity",
     printings: [{
@@ -460363,7 +460363,7 @@ If a card has been put into your soul this turn, instead draw 3 cards.`,
     classes: [Class.NotClassed],
     defaultImage: "UPR089",
     firstReleaseDate: "2022-06-24",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Cindra,Hero.Dromai,Hero.Emperor,Hero.Fai,Hero.Fang,Hero.Librarian,Hero.Taipanis],
     name: "Tome of Firebrand",
     printings: [{
@@ -460444,7 +460444,7 @@ Draw 2 cards.`,
     classes: [Class.Generic],
     defaultImage: "U-WTR160",
     firstReleaseDate: "2019-10-11",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Arakni,Hero.Aurora,Hero.Aurora2,Hero.Azalea,Hero.Baalghor,Hero.Benji,Hero.Betsy,Hero.Blaze,Hero.Bolfar,Hero.Boltyn,Hero.Bravo,Hero.Brevant,Hero.Briar,Hero.Broscilio,Hero.Brutus,Hero.Chane,Hero.Cindra,Hero.Crackni,Hero.Crix,Hero.Dash,Hero.DataDoll,Hero.Dorinthea,Hero.Dromai,Hero.Enigma,Hero.Fai,Hero.Fang,Hero.Florian,Hero.Frankie,Hero.Genis,Hero.GravyBones,Hero.Hala,Hero.Ira,Hero.Iyslander,Hero.Jarl,Hero.Kano,Hero.Kassai,Hero.Katsu,Hero.Kavdaen,Hero.Kayo,Hero.Killjoy,Hero.Kox,Hero.Levia,Hero.Lexi,Hero.Librarian,Hero.Lyath,Hero.Malice,Hero.Marlynn,Hero.Maxx,Hero.Melody,Hero.Mortimer,Hero.Nuu,Hero.Oldhim,Hero.Olympia,Hero.Oscilio,Hero.Pleiades,Hero.Prism,Hero.Puffin,Hero.RKO,Hero.Reya,Hero.Rhinar,Hero.Riptide,Hero.Ruudi,Hero.Scurv,Hero.Shiyana,Hero.Slippy,Hero.Squizzy,Hero.Starvo,Hero.Taipanis,Hero.Taylor,Hero.Teklovossen,Hero.Terra,Hero.Theryon,Hero.Tuffnut,Hero.Uzuri,Hero.Valda,Hero.Verdance,Hero.Victor,Hero.Viserai,Hero.Viserai2,Hero.Vynnset,Hero.Yoji,Hero.Yorick,Hero.Zane,Hero.Zen,Hero.Zyggy],
     name: "Tome of Fyendal",
     printings: [{
@@ -471008,7 +471008,7 @@ You may shuffle a Hyper Driver from your graveyard into your deck. If you do, ga
     typeText: "Shadow Necromancer Equipment - Arms",
 
     
-    
+    bannedFormats: [Format.SilverAge],
     
     defense: 1,
     
@@ -475430,7 +475430,7 @@ If Ursur is attacking a hero with 1 or more cards in their soul, the attack gets
     typeText: "Shadow Runeblade Action - Attack",
 
     
-    
+    bannedFormats: [Format.SilverAge],
     cost: 13,
     defense: 3,
     
@@ -477624,7 +477624,7 @@ When this defends, you may pay {r}. If you do, it gets +1{d} and **blade break**
     classes: [Class.Runeblade],
     defaultImage: "DTD158",
     firstReleaseDate: "2023-07-14",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.UltimatePitFight],
     legalHeroes: [Hero.Chane,Hero.Viserai2,Hero.Vynnset],
     name: "Vantom Wraith",
     printings: [{
@@ -477705,7 +477705,7 @@ When this defends, you may pay {r}. If you do, it gets +1{d} and **blade break**
     classes: [Class.Runeblade],
     defaultImage: "DTD159",
     firstReleaseDate: "2023-07-14",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.UltimatePitFight],
     legalHeroes: [Hero.Chane,Hero.Viserai2,Hero.Vynnset],
     name: "Vantom Wraith",
     printings: [{
@@ -477786,7 +477786,7 @@ When this defends, you may pay {r}. If you do, it gets +1{d} and **blade break**
     classes: [Class.Runeblade],
     defaultImage: "DTD160",
     firstReleaseDate: "2023-07-14",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.UltimatePitFight],
     legalHeroes: [Hero.Chane,Hero.Viserai2,Hero.Vynnset],
     name: "Vantom Wraith",
     printings: [{
@@ -479506,7 +479506,7 @@ If you've pitched a blue card this turn, create a Fang Strike in your hand.`,
     classes: [Class.Generic],
     defaultImage: "U-ARC152",
     firstReleaseDate: "2020-03-27",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Arakni,Hero.Aurora,Hero.Aurora2,Hero.Azalea,Hero.Baalghor,Hero.Benji,Hero.Betsy,Hero.Blaze,Hero.Bolfar,Hero.Boltyn,Hero.Bravo,Hero.Brevant,Hero.Briar,Hero.Broscilio,Hero.Brutus,Hero.Chane,Hero.Cindra,Hero.Crackni,Hero.Crix,Hero.Dash,Hero.DataDoll,Hero.Dorinthea,Hero.Dromai,Hero.Emperor,Hero.Enigma,Hero.Fai,Hero.Fang,Hero.Florian,Hero.Frankie,Hero.Genis,Hero.GravyBones,Hero.Hala,Hero.Ira,Hero.Iyslander,Hero.Jarl,Hero.Kano,Hero.Kassai,Hero.Katsu,Hero.Kavdaen,Hero.Kayo,Hero.Killjoy,Hero.Kox,Hero.Levia,Hero.Lexi,Hero.Librarian,Hero.Lyath,Hero.Malice,Hero.Marlynn,Hero.Maxx,Hero.Melody,Hero.Mortimer,Hero.Nuu,Hero.Oldhim,Hero.Olympia,Hero.Oscilio,Hero.Pleiades,Hero.Prism,Hero.Puffin,Hero.RKO,Hero.Reya,Hero.Rhinar,Hero.Riptide,Hero.Ruudi,Hero.Scurv,Hero.Shiyana,Hero.Slippy,Hero.Squizzy,Hero.Starvo,Hero.Taipanis,Hero.Taylor,Hero.Teklovossen,Hero.Terra,Hero.Theryon,Hero.Tuffnut,Hero.Uzuri,Hero.Valda,Hero.Verdance,Hero.Victor,Hero.Viserai,Hero.Viserai2,Hero.Vynnset,Hero.Yoji,Hero.Yorick,Hero.Zane,Hero.Zen,Hero.Zyggy],
     name: "Vest of the First Fist",
     printings: [{
@@ -483808,7 +483808,7 @@ When this chain link resolves, if this is defended by a card from hand, create a
     typeText: "Shadow Runeblade Hero - Young",
 
     
-    
+    bannedFormats: [Format.LivingLegend],
     createdExtras: ["runechant"],
     
     
@@ -484077,7 +484077,7 @@ When this chain link resolves, if this is defended by a card from hand, create a
     typeText: "Shadow Runeblade Hero",
 
     
-    
+    bannedFormats: [Format.SilverAge],
     createdExtras: ["runechant"],
     
     
@@ -485967,7 +485967,7 @@ When this hits, create a Lightning Flow token.
     classes: [Class.Ranger],
     defaultImage: "U-ELE034",
     firstReleaseDate: "2021-09-24",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Lexi],
     name: "Voltaire, Strike Twice",
     printings: [{
@@ -487240,7 +487240,7 @@ When this hits, create a Lightning Flow token.`,
     classes: [Class.Wizard],
     defaultImage: "ROS021",
     firstReleaseDate: "2024-09-20",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Broscilio,Hero.Oscilio],
     name: "Volzar, the Lightning Rod",
     printings: [{
@@ -490091,7 +490091,7 @@ When this hits, you may discard a card with cost 0. If you do, search your deck 
     classes: [Class.Wizard],
     defaultImage: "UPR165",
     firstReleaseDate: "2022-06-24",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Blaze,Hero.Broscilio,Hero.Emperor,Hero.Iyslander,Hero.Kano,Hero.Oscilio,Hero.Verdance],
     name: "Waning Moon",
     printings: [{
@@ -500542,7 +500542,7 @@ When this is pitched, **amp 1**.`,
     classes: [Class.Guardian],
     defaultImage: "U-ELE003",
     firstReleaseDate: "2021-09-24",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.UltimatePitFight],
     legalHeroes: [Hero.Jarl,Hero.Oldhim,Hero.Starvo,Hero.Terra],
     name: "Winter's Wail",
     printings: [{
@@ -502312,7 +502312,7 @@ When this hits a hero, create a Frailty token under their control.`,
     classes: [Class.Ninja],
     defaultImage: "HNT061",
     firstReleaseDate: "2025-01-31",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Draft,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.Sealed,Format.SilverAge,Format.UltimatePitFight],
     legalHeroes: [Hero.Cindra,Hero.Fai],
     name: "Wrath of Retribution",
     printings: [{
@@ -505962,7 +505962,7 @@ If this has been sharpened this turn, its first attack this turn gets **go again
     classes: [Class.Ninja],
     defaultImage: "U-CRU051",
     firstReleaseDate: "2020-08-28",
-    legalFormats: [Format.Blitz,Format.ClassicConstructed,Format.GoldenAge,Format.LivingLegend,Format.Open,Format.SilverAge,Format.UltimatePitFight],
+    legalFormats: [Format.Blitz,Format.Open,Format.UltimatePitFight],
     legalHeroes: [Hero.Benji,Hero.Cindra,Hero.Fai,Hero.Ira,Hero.Katsu,Hero.Zen],
     name: "Zephyr Needle",
     printings: [{

--- a/packages/cards/tests/__snapshots__/card-properties.test.ts.snap
+++ b/packages/cards/tests/__snapshots__/card-properties.test.ts.snap
@@ -3654,7 +3654,6 @@ The next card you play this turn with an arcane damage effect, instead deals tha
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -3801,7 +3800,6 @@ The next card you play this turn with an arcane damage effect, instead deals tha
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -3949,7 +3947,6 @@ The next card you play this turn with an arcane damage effect, instead deals tha
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -4736,7 +4733,6 @@ exports[`Check for unintentional updates Aether Ironweave (aether-ironweave) vs 
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -12496,6 +12492,9 @@ exports[`Check for unintentional updates Ancient Earth Oak (ancient-earth-oak-re
   "artists": [
     "Rio Sabda",
   ],
+  "bannedFormats": [
+    "Silver Age",
+  ],
   "bonds": [
     "Earth",
   ],
@@ -15193,6 +15192,9 @@ exports[`Check for unintentional updates Apex Buster (apex-buster-yellow) vs sna
 {
   "artists": [
     "Surya Feby",
+  ],
+  "bannedFormats": [
+    "Silver Age",
   ],
   "cardIdentifier": "apex-buster-yellow",
   "classes": [
@@ -23771,9 +23773,7 @@ exports[`Check for unintentional updates Art of War (art-of-war-yellow) vs snaps
 - You may banish an attack action card from your hand. If you do, draw 2 cards.",
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
-    "Golden Age",
     "Living Legend",
     "Open",
     "Sealed",
@@ -25614,6 +25614,9 @@ exports[`Check for unintentional updates Astral Ambience (astral-ambience-yellow
 {
   "artists": [
     "Reinaldo Indrajaya",
+  ],
+  "bannedFormats": [
+    "Silver Age",
   ],
   "cardIdentifier": "astral-ambience-yellow",
   "classes": [
@@ -28983,9 +28986,7 @@ Search your deck for a Guardian attack action card with cost less than or equal 
   ],
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
-    "Golden Age",
     "Living Legend",
     "Open",
     "Sealed",
@@ -30102,7 +30103,6 @@ Attack action cards played from your banished zone get +3{p}.",
   "legalFormats": [
     "Blitz",
     "Open",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -33196,13 +33196,11 @@ exports[`Check for unintentional updates Ball Lightning (ball-lightning-blue) vs
   ],
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
     "Golden Age",
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -33335,13 +33333,11 @@ exports[`Check for unintentional updates Ball Lightning (ball-lightning-red) vs 
   ],
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
     "Golden Age",
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -33474,13 +33470,11 @@ exports[`Check for unintentional updates Ball Lightning (ball-lightning-yellow) 
   ],
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
     "Golden Age",
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -39865,6 +39859,9 @@ exports[`Check for unintentional updates Battle Clearing Bellow (battle-clearing
   "artists": [
     "Dzulfikar Aliy",
   ],
+  "bannedFormats": [
+    "Silver Age",
+  ],
   "cardIdentifier": "battle-clearing-bellow-blue",
   "classes": [
     "Brute",
@@ -44483,7 +44480,6 @@ exports[`Check for unintentional updates Beckoning Haunt (beckoning-haunt) vs sn
     "Golden Age",
     "Living Legend",
     "Open",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -44988,7 +44984,6 @@ When this hits, your next blue attack this turn gets +1{p} and **go again**.",
   ],
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
     "Golden Age",
     "Living Legend",
@@ -45858,6 +45853,9 @@ exports[`Check for unintentional updates Become the Shadow Lord (become-the-shad
   "artists": [
     "Athiwut B.",
   ],
+  "bannedFormats": [
+    "Silver Age",
+  ],
   "cardIdentifier": "become-the-shadow-lord-blue",
   "classes": [
     "Runeblade",
@@ -45979,13 +45977,11 @@ When the additional cost is paid, search your deck for a Minnowism, reveal it, p
   ],
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
     "Golden Age",
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -46199,13 +46195,11 @@ When the additional cost is paid, search your deck for a Minnowism, reveal it, p
   ],
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
     "Golden Age",
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -46420,13 +46414,11 @@ When the additional cost is paid, search your deck for a Minnowism, reveal it, p
   ],
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
     "Golden Age",
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -47479,8 +47471,6 @@ exports[`Check for unintentional updates Berserk (berserk-yellow) vs snapshot 1`
   ],
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
-    "Golden Age",
     "Living Legend",
     "Open",
     "Ultimate Pit Fight",
@@ -64660,6 +64650,9 @@ exports[`Check for unintentional updates Blood Harvest (blood-harvest) vs snapsh
   "artists": [
     "Khairul Sukmanudin",
   ],
+  "bannedFormats": [
+    "Silver Age",
+  ],
   "cardIdentifier": "blood-harvest",
   "classes": [
     "Brute",
@@ -66673,8 +66666,6 @@ exports[`Check for unintentional updates Bloodsheath Skeleta (bloodsheath-skelet
   ],
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
-    "Golden Age",
     "Living Legend",
     "Open",
     "Ultimate Pit Fight",
@@ -71158,7 +71149,6 @@ If you've played or activated 3 or more attack reactions this chain link, this g
   ],
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
     "Golden Age",
     "Living Legend",
@@ -71256,13 +71246,11 @@ exports[`Check for unintentional updates Bonds of Ancestry (bonds-of-ancestry-bl
   ],
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
     "Golden Age",
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -71364,7 +71352,6 @@ exports[`Check for unintentional updates Bonds of Ancestry (bonds-of-ancestry-re
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -71478,13 +71465,11 @@ exports[`Check for unintentional updates Bonds of Ancestry (bonds-of-ancestry-ye
   ],
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
     "Golden Age",
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -72206,6 +72191,9 @@ exports[`Check for unintentional updates Bone Barrier (bone-barrier-blue) vs sna
 {
   "artists": [
     "Khairul Sukmanudin",
+  ],
+  "bannedFormats": [
+    "Silver Age",
   ],
   "cardIdentifier": "bone-barrier-blue",
   "classes": [
@@ -75518,7 +75506,6 @@ exports[`Check for unintentional updates Bracers of Belief (bracers-of-belief) v
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -76877,7 +76864,6 @@ exports[`Check for unintentional updates Brand with Cinderclaw (brand-with-cinde
   ],
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
     "Golden Age",
     "Living Legend",
@@ -76993,7 +76979,6 @@ exports[`Check for unintentional updates Brand with Cinderclaw (brand-with-cinde
   ],
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
     "Golden Age",
     "Living Legend",
@@ -77125,7 +77110,6 @@ exports[`Check for unintentional updates Brand with Cinderclaw (brand-with-cinde
   ],
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
     "Golden Age",
     "Living Legend",
@@ -81674,6 +81658,9 @@ exports[`Check for unintentional updates Bridge of Damnation (bridge-of-damnatio
 {
   "artists": [
     "Arkoii",
+  ],
+  "bannedFormats": [
+    "Silver Age",
   ],
   "cardIdentifier": "bridge-of-damnation-blue",
   "classes": [
@@ -92892,7 +92879,6 @@ At the start of your turn, if you have 13 or less {h}, banish this.
     "Classic Constructed",
     "Draft",
     "Golden Age",
-    "Living Legend",
     "Open",
     "Sealed",
     "Ultimate Pit Fight",
@@ -93668,8 +93654,6 @@ Draw 2 cards.
   ],
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
-    "Golden Age",
     "Living Legend",
     "Open",
     "Silver Age",
@@ -95724,6 +95708,9 @@ exports[`Check for unintentional updates Chains of Consecration (chains-of-conse
   "artists": [
     "Vincent Taslim",
   ],
+  "bannedFormats": [
+    "Silver Age",
+  ],
   "cardIdentifier": "chains-of-consecration-yellow",
   "classes": [
     "NotClassed",
@@ -96924,9 +96911,7 @@ exports[`Check for unintentional updates Channel Lightning Valley (channel-light
   ],
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
-    "Golden Age",
     "Living Legend",
     "Open",
     "Sealed",
@@ -98559,7 +98544,6 @@ Create a Gold token for each yellow card put into your graveyard this way.
   ],
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
     "Golden Age",
     "Living Legend",
@@ -104009,6 +103993,9 @@ exports[`Check for unintentional updates Circlet of Eternal End (circlet-of-eter
 {
   "artists": [
     "Carlos Cruchaga",
+  ],
+  "bannedFormats": [
+    "Silver Age",
   ],
   "cardIdentifier": "circlet-of-eternal-end",
   "classes": [
@@ -124641,6 +124628,9 @@ exports[`Check for unintentional updates Corrupt and Conquer (corrupt-and-conque
   "artists": [
     "Jessada Sutthi",
   ],
+  "bannedFormats": [
+    "Classic Constructed",
+  ],
   "cardIdentifier": "corrupt-and-conquer-red",
   "classes": [
     "NotClassed",
@@ -124659,7 +124649,6 @@ When this hits a hero, banish all cards in their arsenal.
   ],
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
     "Golden Age",
     "Living Legend",
@@ -125771,7 +125760,6 @@ Your aura attacks with one or more +1{p} counters get **go again**.",
   ],
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
     "Golden Age",
     "Living Legend",
@@ -125916,13 +125904,10 @@ exports[`Check for unintentional updates Count Your Blessings (count-your-blessi
   "functionalText": "Gain X{h}, where X is 1 plus the number of Count Your Blessings in your graveyard.",
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
-    "Golden Age",
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -126113,13 +126098,10 @@ exports[`Check for unintentional updates Count Your Blessings (count-your-blessi
   "functionalText": "Gain X{h}, where X is 3 plus the number of Count Your Blessings in your graveyard.",
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
-    "Golden Age",
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -126311,13 +126293,10 @@ exports[`Check for unintentional updates Count Your Blessings (count-your-blessi
   "functionalText": "Gain X{h}, where X is 2 plus the number of Count Your Blessings in your graveyard.",
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
-    "Golden Age",
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -134613,10 +134592,8 @@ exports[`Check for unintentional updates Crown of Seeds (crown-of-seeds) vs snap
   "functionalText": "**Once per Turn Instant** - {r}, put a face-down card from your arsenal on the bottom of your deck: Draw a card and prevent the next 1 damage that would be dealt to you this turn.",
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
     "Golden Age",
-    "Living Legend",
     "Open",
     "Sealed",
     "Ultimate Pit Fight",
@@ -134728,7 +134705,6 @@ exports[`Check for unintentional updates Crucible of Aetherweave (crucible-of-ae
   "functionalText": "**Once per Turn Instant** - {r}: The next card you play this turn with an arcane damage effect, instead deals that much arcane damage plus 1.",
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
     "Golden Age",
     "Living Legend",
@@ -136181,6 +136157,9 @@ exports[`Check for unintentional updates Crushing Headache (crushing-headache-re
 {
   "artists": [
     "Yunior Susanto",
+  ],
+  "bannedFormats": [
+    "Silver Age",
   ],
   "cardIdentifier": "crushing-headache-red",
   "classes": [
@@ -141174,6 +141153,9 @@ exports[`Check for unintentional updates Danse Macabre (danse-macabre) vs snapsh
   "artists": [
     "Amtepra",
   ],
+  "bannedFormats": [
+    "Silver Age",
+  ],
   "cardIdentifier": "danse-macabre",
   "classes": [
     "Necromancer",
@@ -144974,6 +144956,9 @@ exports[`Check for unintentional updates Deadly Spinneret (deadly-spinneret-red)
   "artists": [
     "Faizal Fikri",
   ],
+  "bannedFormats": [
+    "Silver Age",
+  ],
   "cardIdentifier": "deadly-spinneret-red",
   "classes": [
     "Assassin",
@@ -145100,7 +145085,6 @@ exports[`Check for unintentional updates Deadwood Dirge (deadwood-dirge-blue) vs
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -145210,7 +145194,6 @@ exports[`Check for unintentional updates Deadwood Dirge (deadwood-dirge-red) vs 
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -145375,7 +145358,6 @@ exports[`Check for unintentional updates Deadwood Dirge (deadwood-dirge-yellow) 
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -145985,7 +145967,6 @@ exports[`Check for unintentional updates Death Dealer (death-dealer) vs snapshot
   ],
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
     "Golden Age",
     "Living Legend",
@@ -146578,7 +146559,6 @@ When the combat chain closes, gain {h} equal to the number of heroes who have lo
     "Golden Age",
     "Living Legend",
     "Open",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -146679,7 +146659,6 @@ When the combat chain closes, gain {h} equal to the number of heroes who have lo
     "Golden Age",
     "Living Legend",
     "Open",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -146780,7 +146759,6 @@ When the combat chain closes, gain {h} equal to the number of heroes who have lo
     "Golden Age",
     "Living Legend",
     "Open",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -154583,6 +154561,9 @@ exports[`Check for unintentional updates Dig for Souls (dig-for-souls-red) vs sn
 {
   "artists": [
     "Diana Tanamas",
+  ],
+  "bannedFormats": [
+    "Silver Age",
   ],
   "cardIdentifier": "dig-for-souls-red",
   "classes": [
@@ -167282,13 +167263,10 @@ exports[`Check for unintentional updates Drone of Brutality (drone-of-brutality-
   "functionalText": "If this would be put into your graveyard from anywhere, instead put it on the bottom of your deck.",
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
-    "Golden Age",
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -167508,13 +167486,10 @@ exports[`Check for unintentional updates Drone of Brutality (drone-of-brutality-
   "functionalText": "If this would be put into your graveyard from anywhere, instead put it on the bottom of your deck.",
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
-    "Golden Age",
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -167756,13 +167731,10 @@ exports[`Check for unintentional updates Drone of Brutality (drone-of-brutality-
   "functionalText": "If this would be put into your graveyard from anywhere, instead put it on the bottom of your deck.",
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
-    "Golden Age",
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -170237,7 +170209,6 @@ When this attacks, if you've played an attack action card and a non-attack actio
 At the beginning of your end phase, if you haven't played an attack action card and a non-attack action card this turn, remove all +1{p} counters from this.",
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
     "Golden Age",
     "Living Legend",
@@ -174032,7 +174003,6 @@ exports[`Check for unintentional updates Ebon Fold (ebon-fold) vs snapshot 1`] =
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -174356,6 +174326,9 @@ exports[`Check for unintentional updates Echoing Trap (echoing-trap-blue) vs sna
 {
   "artists": [
     "Aluísio Cervelle",
+  ],
+  "bannedFormats": [
+    "Silver Age",
   ],
   "cardIdentifier": "echoing-trap-blue",
   "classes": [
@@ -177790,11 +177763,9 @@ exports[`Check for unintentional updates Electromagnetic Somersault (electromagn
     "Blitz",
     "Classic Constructed",
     "Draft",
-    "Golden Age",
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -177889,13 +177860,10 @@ exports[`Check for unintentional updates Electromagnetic Somersault (electromagn
   "functionalText": "Choose up to 2 attack action cards with cost 0 or more on the active chain link. Return them to their owner's hand when the chain link resolves.",
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
-    "Golden Age",
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -178007,13 +177975,10 @@ exports[`Check for unintentional updates Electromagnetic Somersault (electromagn
   "functionalText": "Choose up to 2 attack action cards with cost 1 or more on the active chain link. Return them to their owner's hand when the chain link resolves.",
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
-    "Golden Age",
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -207267,7 +207232,6 @@ exports[`Check for unintentional updates Fate Foreseen (fate-foreseen-blue) vs s
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -207493,7 +207457,6 @@ exports[`Check for unintentional updates Fate Foreseen (fate-foreseen-red) vs sn
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -207796,7 +207759,6 @@ exports[`Check for unintentional updates Fate Foreseen (fate-foreseen-yellow) vs
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -211497,7 +211459,6 @@ exports[`Check for unintentional updates Fiddler's Green (fiddlers-green-blue) v
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -211667,7 +211628,6 @@ exports[`Check for unintentional updates Fiddler's Green (fiddlers-green-red) vs
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -211915,7 +211875,6 @@ exports[`Check for unintentional updates Fiddler's Green (fiddlers-green-yellow)
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -220954,7 +220913,6 @@ exports[`Check for unintentional updates Flic Flak (flic-flak-blue) vs snapshot 
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -221135,7 +221093,6 @@ exports[`Check for unintentional updates Flic Flak (flic-flak-red) vs snapshot 1
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -221336,7 +221293,6 @@ exports[`Check for unintentional updates Flic Flak (flic-flak-yellow) vs snapsho
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -224280,7 +224236,6 @@ exports[`Check for unintentional updates Flourish (flourish-blue) vs snapshot 1`
     "Golden Age",
     "Living Legend",
     "Open",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -224365,7 +224320,6 @@ exports[`Check for unintentional updates Flourish (flourish-yellow) vs snapshot 
     "Golden Age",
     "Living Legend",
     "Open",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -229255,6 +229209,9 @@ exports[`Check for unintentional updates Forsaken Strike (forsaken-strike-yellow
 {
   "artists": [
     "Tanapon Wachirakul",
+  ],
+  "bannedFormats": [
+    "Silver Age",
   ],
   "cardIdentifier": "forsaken-strike-yellow",
   "classes": [
@@ -237769,7 +237726,6 @@ If you've played a card from your banished zone this turn, this gets +2{p}.
 When this hits a hero, deal 1 arcane damage to them.",
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
     "Golden Age",
     "Living Legend",
@@ -249653,7 +249609,6 @@ exports[`Check for unintentional updates Golden Tipple (golden-tipple-red) vs sn
   ],
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
     "Golden Age",
     "Living Legend",
@@ -249793,7 +249748,6 @@ exports[`Check for unintentional updates Golden Tipple (golden-tipple-yellow) vs
   ],
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
     "Golden Age",
     "Living Legend",
@@ -250580,7 +250534,6 @@ exports[`Check for unintentional updates Goliath Gauntlet (goliath-gauntlet) vs 
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -263176,6 +263129,9 @@ exports[`Check for unintentional updates Head Banging Chorus (head-banging-choru
   "artists": [
     "Bramasta Aji",
   ],
+  "bannedFormats": [
+    "Silver Age",
+  ],
   "cardIdentifier": "head-banging-chorus-yellow",
   "classes": [
     "Guardian",
@@ -266698,7 +266654,6 @@ exports[`Check for unintentional updates Heartened Cross Strap (heartened-cross-
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -268553,7 +268508,6 @@ exports[`Check for unintentional updates Heavy Industry Power Plant (heavy-indus
   "legalFormats": [
     "Blitz",
     "Classic Constructed",
-    "Golden Age",
     "Living Legend",
     "Open",
     "Ultimate Pit Fight",
@@ -277121,7 +277075,6 @@ Draw a card.
   ],
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
     "Golden Age",
     "Living Legend",
@@ -282442,7 +282395,6 @@ exports[`Check for unintentional updates Honing Hood (honing-hood) vs snapshot 1
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -290273,6 +290225,9 @@ exports[`Check for unintentional updates Ice Aged Oak (ice-aged-oak-blue) vs sna
 {
   "artists": [
     "Kevin Sidharta",
+  ],
+  "bannedFormats": [
+    "Silver Age",
   ],
   "cardIdentifier": "ice-aged-oak-blue",
   "classes": [
@@ -299074,6 +299029,9 @@ exports[`Check for unintentional updates Ingest the Unknown (ingest-the-unknown-
   "artists": [
     "Tomasz Jedruszek",
   ],
+  "bannedFormats": [
+    "Silver Age",
+  ],
   "cardIdentifier": "ingest-the-unknown-yellow",
   "classes": [
     "Brute",
@@ -304739,7 +304697,6 @@ exports[`Check for unintentional updates Ira, Crimson Haze (ira-crimson-haze) vs
   "legalFormats": [
     "Blitz",
     "Open",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -312531,7 +312488,6 @@ exports[`Check for unintentional updates Kano (kano) vs snapshot 1`] = `
     "Draft",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -313941,7 +313897,6 @@ The first time you discard a card with 6 or more {p} during each of your action 
     "Draft",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -317032,9 +316987,6 @@ exports[`Check for unintentional updates Kraken's Aethervein (krakens-aethervein
   "functionalText": "**Once per Turn Instant** - {r}{r}{r}: Deal 1 arcane damage to target opposing hero. Draw a card for each arcane damage dealt this way.",
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
-    "Golden Age",
-    "Living Legend",
     "Open",
     "Ultimate Pit Fight",
   ],
@@ -335274,7 +335226,6 @@ If there is a yellow card in your pitch zone, your Illusionist attacks get **go 
   ],
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
     "Golden Age",
     "Living Legend",
@@ -335455,7 +335406,6 @@ exports[`Check for unintentional updates Luminaris, Angel's Glow (luminaris-ange
   ],
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Golden Age",
     "Living Legend",
     "Open",
@@ -335547,7 +335497,6 @@ exports[`Check for unintentional updates Luminaris, Celestial Fury (luminaris-ce
   ],
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Golden Age",
     "Living Legend",
     "Open",
@@ -339082,6 +339031,9 @@ exports[`Check for unintentional updates Malice (malice) vs snapshot 1`] = `
   "artists": [
     "João G. Santos",
   ],
+  "bannedFormats": [
+    "Living Legend",
+  ],
   "cardIdentifier": "malice",
   "classes": [
     "Necromancer",
@@ -339190,6 +339142,9 @@ exports[`Check for unintentional updates Malice, Domina of the Dead (malice-domi
 {
   "artists": [
     "João G. Santos",
+  ],
+  "bannedFormats": [
+    "Silver Age",
   ],
   "cardIdentifier": "malice-domina-of-the-dead",
   "classes": [
@@ -339949,7 +339904,6 @@ If you've discarded a card with 6 or more {p} this turn, this card's attacks get
   ],
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
     "Golden Age",
     "Living Legend",
@@ -344008,7 +343962,6 @@ exports[`Check for unintentional updates Mask of Three Tails (mask-of-three-tail
     "Golden Age",
     "Living Legend",
     "Open",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -351174,7 +351127,6 @@ When this hits a hero, **clash** with them. If you win, destroy the top card of 
   ],
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
     "Golden Age",
     "Living Legend",
@@ -357024,7 +356976,6 @@ exports[`Check for unintentional updates Mordred Tide (mordred-tide-red) vs snap
     "Blitz",
     "Classic Constructed",
     "Draft",
-    "Golden Age",
     "Living Legend",
     "Open",
     "Sealed",
@@ -360555,7 +360506,6 @@ When this hits, create a Runechant token.
 If you've played a non-attack action card this turn, this gets +3{p}.",
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
     "Golden Age",
     "Living Legend",
@@ -363619,7 +363569,6 @@ exports[`Check for unintentional updates Nimby (nimby-blue) vs snapshot 1`] = `
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -363798,7 +363747,6 @@ exports[`Check for unintentional updates Nimby (nimby-red) vs snapshot 1`] = `
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -364018,7 +363966,6 @@ exports[`Check for unintentional updates Nimby (nimby-yellow) vs snapshot 1`] = 
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -371493,7 +371440,6 @@ exports[`Check for unintentional updates Old Knocker (old-knocker) vs snapshot 1
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -376121,7 +376067,6 @@ exports[`Check for unintentional updates Open the Flood Gates (open-the-flood-ga
     "Blitz",
     "Classic Constructed",
     "Draft",
-    "Golden Age",
     "Living Legend",
     "Open",
     "Sealed",
@@ -376241,7 +376186,6 @@ exports[`Check for unintentional updates Open the Flood Gates (open-the-flood-ga
     "Blitz",
     "Classic Constructed",
     "Draft",
-    "Golden Age",
     "Living Legend",
     "Open",
     "Sealed",
@@ -376345,7 +376289,6 @@ exports[`Check for unintentional updates Open the Flood Gates (open-the-flood-ga
     "Blitz",
     "Classic Constructed",
     "Draft",
-    "Golden Age",
     "Living Legend",
     "Open",
     "Sealed",
@@ -376426,6 +376369,9 @@ exports[`Check for unintentional updates Open the Gate to i'Arathael (open-the-g
   "artists": [
     "Jessada Sutthi",
   ],
+  "bannedFormats": [
+    "Classic Constructed",
+  ],
   "cardIdentifier": "open-the-gate-to-iarathael-red",
   "classes": [
     "NotClassed",
@@ -376445,7 +376391,6 @@ exports[`Check for unintentional updates Open the Gate to i'Arathael (open-the-g
   ],
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
     "Golden Age",
     "Living Legend",
@@ -376713,7 +376658,6 @@ Your next attack with **stealth** this turn gets +1{p}.
   ],
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
     "Golden Age",
     "Living Legend",
@@ -376985,7 +376929,6 @@ Your next attack with **stealth** this turn gets +2{p}.
   ],
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
     "Golden Age",
     "Living Legend",
@@ -377246,9 +377189,7 @@ Draw 2 cards. If a Chi was pitched to play this, instead draw 3 cards.",
   ],
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
-    "Golden Age",
     "Living Legend",
     "Open",
     "Sealed",
@@ -394090,7 +394031,6 @@ exports[`Check for unintentional updates Phantom Tidemaw (phantom-tidemaw-blue) 
   ],
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Golden Age",
     "Living Legend",
     "Open",
@@ -400710,7 +400650,6 @@ exports[`Check for unintentional updates Plume of Evergrowth (plume-of-evergrowt
   "functionalText": "**Instant** - {r}{r}{r}, destroy this: Return target Earth action card or Earth instant card from your graveyard to your hand.",
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
     "Golden Age",
     "Living Legend",
@@ -400883,13 +400822,11 @@ If this was played from arsenal, the next attack action card you play this turn 
   ],
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
     "Golden Age",
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -401117,13 +401054,11 @@ If this was played from arsenal, the next attack action card you play this turn 
   ],
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
     "Golden Age",
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -401352,13 +401287,11 @@ If this was played from arsenal, the next attack action card you play this turn 
   ],
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
     "Golden Age",
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -414006,7 +413939,6 @@ exports[`Check for unintentional updates Prism, Advent of Thrones (prism-advent-
   "legalFormats": [
     "Blitz",
     "Open",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -430082,7 +430014,6 @@ exports[`Check for unintentional updates Ragamuffin's Hat (ragamuffins-hat) vs s
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -439154,6 +439085,9 @@ exports[`Check for unintentional updates Reach of the Abyss (reach-of-the-abyss)
   "artists": [
     "Saad Irfan",
   ],
+  "bannedFormats": [
+    "Silver Age",
+  ],
   "cardIdentifier": "reach-of-the-abyss",
   "classes": [
     "NotClassed",
@@ -440552,7 +440486,6 @@ exports[`Check for unintentional updates Reality Refractor (reality-refractor) v
     "Golden Age",
     "Living Legend",
     "Open",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -441046,11 +440979,9 @@ exports[`Check for unintentional updates Reaping Blade (reaping-blade) vs snapsh
 If a hero has more {h} than each other hero, they can't gain {h}.",
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Golden Age",
     "Living Legend",
     "Open",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -448433,9 +448364,7 @@ exports[`Check for unintentional updates Remembrance (remembrance-yellow) vs sna
 Banish this.",
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
-    "Golden Age",
     "Living Legend",
     "Open",
     "Sealed",
@@ -450161,6 +450090,9 @@ exports[`Check for unintentional updates Restless Commander (restless-commander-
 {
   "artists": [
     "Joseph Qiu",
+  ],
+  "bannedFormats": [
+    "Silver Age",
   ],
   "cardIdentifier": "restless-commander-red",
   "classes": [
@@ -466360,13 +466292,10 @@ exports[`Check for unintentional updates Rosetta Thorn (rosetta-thorn) vs snapsh
 When this attacks, if you've played an attack action card and a non-attack action card this turn, deal 2 arcane damage to target hero.",
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
     "Golden Age",
-    "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -467204,7 +467133,6 @@ exports[`Check for unintentional updates Rotwood Reaper (rotwood-reaper) vs snap
 If you've played or created an aura this turn, this gets +2{p}.",
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
     "Golden Age",
     "Living Legend",
@@ -474441,6 +474369,9 @@ exports[`Check for unintentional updates Runic Reaving (runic-reaving-red) vs sn
     "Nailsen Ivanderlie",
     "Nino Setiawan",
   ],
+  "bannedFormats": [
+    "Silver Age",
+  ],
   "cardIdentifier": "runic-reaving-red",
   "classes": [
     "Runeblade",
@@ -474466,7 +474397,6 @@ exports[`Check for unintentional updates Runic Reaving (runic-reaving-red) vs sn
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -474987,6 +474917,9 @@ exports[`Check for unintentional updates Rush of Knowledge (rush-of-knowledge-bl
 {
   "artists": [
     "Nailsen Ivanderlie",
+  ],
+  "bannedFormats": [
+    "Silver Age",
   ],
   "cardIdentifier": "rush-of-knowledge-blue",
   "classes": [
@@ -512835,7 +512768,6 @@ exports[`Check for unintentional updates Sigil of Solace (sigil-of-solace-blue) 
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -513120,7 +513052,6 @@ exports[`Check for unintentional updates Sigil of Solace (sigil-of-solace-red) v
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -513452,7 +513383,6 @@ exports[`Check for unintentional updates Sigil of Solace (sigil-of-solace-yellow
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -514707,6 +514637,9 @@ exports[`Check for unintentional updates Sigil of the Muse (sigil-of-the-muse-re
 {
   "artists": [
     "Agatha Maura",
+  ],
+  "bannedFormats": [
+    "Silver Age",
   ],
   "cardIdentifier": "sigil-of-the-muse-red",
   "classes": [
@@ -518992,7 +518925,6 @@ exports[`Check for unintentional updates Sink Below (sink-below-blue) vs snapsho
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -519216,7 +519148,6 @@ exports[`Check for unintentional updates Sink Below (sink-below-red) vs snapshot
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -519583,7 +519514,6 @@ exports[`Check for unintentional updates Sink Below (sink-below-yellow) vs snaps
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -519878,6 +519808,9 @@ exports[`Check for unintentional updates Sinspeaker Gloomblade (sinspeaker-gloom
   "artists": [
     "soyameii",
   ],
+  "bannedFormats": [
+    "Silver Age",
+  ],
   "cardIdentifier": "sinspeaker-gloomblade-red",
   "classes": [
     "Runeblade",
@@ -520078,7 +520011,6 @@ exports[`Check for unintentional updates Sirens of Safe Harbor (sirens-of-safe-h
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -520252,7 +520184,6 @@ exports[`Check for unintentional updates Sirens of Safe Harbor (sirens-of-safe-h
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -520470,7 +520401,6 @@ exports[`Check for unintentional updates Sirens of Safe Harbor (sirens-of-safe-h
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -523452,7 +523382,6 @@ exports[`Check for unintentional updates Skyward Serenade (skyward-serenade-yell
   "legalFormats": [
     "Blitz",
     "Classic Constructed",
-    "Golden Age",
     "Living Legend",
     "Open",
     "Ultimate Pit Fight",
@@ -530934,7 +530863,6 @@ exports[`Check for unintentional updates Snapdragon Scalers (snapdragon-scalers)
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -534192,6 +534120,9 @@ exports[`Check for unintentional updates Sonata Dystopia (sonata-dystopia-blue) 
   "artists": [
     "Arkoii",
   ],
+  "bannedFormats": [
+    "Silver Age",
+  ],
   "cardIdentifier": "sonata-dystopia-blue",
   "classes": [
     "Runeblade",
@@ -536935,6 +536866,9 @@ exports[`Check for unintentional updates Soul of Existence (soul-of-existence-pu
 {
   "artists": [
     "Nathaniel Himawan",
+  ],
+  "bannedFormats": [
+    "Silver Age",
   ],
   "cardIdentifier": "soul-of-existence-purple",
   "classes": [
@@ -550847,7 +550781,6 @@ When one or more Earth cards are pitched this way, the next time you deal arcane
   ],
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
     "Golden Age",
     "Living Legend",
@@ -552322,7 +552255,6 @@ If you've played a Lightning card this turn, this card's attacks get +1{p} and *
   ],
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
     "Golden Age",
     "Living Legend",
@@ -558683,6 +558615,9 @@ exports[`Check for unintentional updates Stoke Vengeance (stoke-vengeance-red) v
   "artists": [
     "YDZ",
   ],
+  "bannedFormats": [
+    "Silver Age",
+  ],
   "cardIdentifier": "stoke-vengeance-red",
   "classes": [
     "Ninja",
@@ -560678,7 +560613,6 @@ exports[`Check for unintentional updates Storm of Sandikai (storm-of-sandikai) v
   "functionalText": "Dragon allies you control get "**Once per Turn Action** - 0: **Attack**".",
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
     "Golden Age",
     "Living Legend",
@@ -565302,13 +565236,10 @@ exports[`Check for unintentional updates Stubby Hammerers (stubby-hammerers) vs 
   ],
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
-    "Golden Age",
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -584246,7 +584177,6 @@ exports[`Check for unintentional updates Teklo Plasma Pistol (teklo-plasma-pisto
   ],
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
     "Golden Age",
     "Living Legend",
@@ -596724,7 +596654,6 @@ When this attacks, the next Crouching Tiger you play this combat chain gets +1{p
   ],
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
     "Golden Age",
     "Living Legend",
@@ -600537,7 +600466,6 @@ exports[`Check for unintentional updates Tome of Aetherwind (tome-of-aetherwind-
 - Draw a card.",
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
     "Golden Age",
     "Living Legend",
@@ -600684,9 +600612,7 @@ exports[`Check for unintentional updates Tome of Divinity (tome-of-divinity-yell
 If a card has been put into your soul this turn, instead draw 3 cards.",
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
-    "Golden Age",
     "Living Legend",
     "Open",
     "Sealed",
@@ -600918,9 +600844,7 @@ exports[`Check for unintentional updates Tome of Firebrand (tome-of-firebrand-re
 Draw 2 cards.",
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
-    "Golden Age",
     "Living Legend",
     "Open",
     "Sealed",
@@ -601015,9 +600939,7 @@ exports[`Check for unintentional updates Tome of Fyendal (tome-of-fyendal-yellow
 If this was played from arsenal, gain 1{h} for each card in your hand.",
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
-    "Golden Age",
     "Living Legend",
     "Open",
     "Sealed",
@@ -614603,6 +614525,9 @@ exports[`Check for unintentional updates Undead Grasp (undead-grasp) vs snapshot
   "artists": [
     "Brian Madya Narendra",
   ],
+  "bannedFormats": [
+    "Silver Age",
+  ],
   "cardIdentifier": "undead-grasp",
   "classes": [
     "Necromancer",
@@ -620332,6 +620257,9 @@ exports[`Check for unintentional updates Usurp the Shadow Throne (usurp-the-shad
   "artists": [
     "Esty Swandana",
   ],
+  "bannedFormats": [
+    "Silver Age",
+  ],
   "cardIdentifier": "usurp-the-shadow-throne-blue",
   "classes": [
     "Runeblade",
@@ -623076,7 +623004,6 @@ exports[`Check for unintentional updates Vantom Wraith (vantom-wraith-blue) vs s
     "Golden Age",
     "Living Legend",
     "Open",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -623175,7 +623102,6 @@ exports[`Check for unintentional updates Vantom Wraith (vantom-wraith-red) vs sn
     "Golden Age",
     "Living Legend",
     "Open",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -623277,7 +623203,6 @@ exports[`Check for unintentional updates Vantom Wraith (vantom-wraith-yellow) vs
     "Golden Age",
     "Living Legend",
     "Open",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -625405,7 +625330,6 @@ exports[`Check for unintentional updates Vest of the First Fist (vest-of-the-fir
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -631162,6 +631086,9 @@ exports[`Check for unintentional updates Viserai, Between Worlds (viserai-betwee
   "artists": [
     "Nathaniel Himawan",
   ],
+  "bannedFormats": [
+    "Living Legend",
+  ],
   "cardIdentifier": "viserai-between-worlds",
   "classes": [
     "Runeblade",
@@ -631629,6 +631556,9 @@ exports[`Check for unintentional updates Viserai, the Forsaken (viserai-the-fors
 {
   "artists": [
     "Nathaniel Himawan",
+  ],
+  "bannedFormats": [
+    "Silver Age",
   ],
   "cardIdentifier": "viserai-the-forsaken",
   "classes": [
@@ -633954,7 +633884,6 @@ exports[`Check for unintentional updates Voltaire, Strike Twice (voltaire-strike
   ],
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
     "Golden Age",
     "Living Legend",
@@ -635488,13 +635417,10 @@ exports[`Check for unintentional updates Volzar, the Lightning Rod (volzar-the-l
   ],
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
-    "Golden Age",
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -639688,7 +639614,6 @@ exports[`Check for unintentional updates Waning Moon (waning-moon) vs snapshot 1
     "Living Legend",
     "Open",
     "Sealed",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [
@@ -652958,7 +652883,6 @@ exports[`Check for unintentional updates Winter's Wail (winters-wail) vs snapsho
 If an Ice card is pitched this way, this gets "When this hits a hero, create a Frostbite token under their control."",
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
     "Golden Age",
     "Living Legend",
@@ -655533,7 +655457,6 @@ When this attacks, daggers you control get +1{p} and cost {r} less to activate t
   ],
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
     "Draft",
     "Golden Age",
     "Living Legend",
@@ -660488,11 +660411,7 @@ When this is defended by a card with {d} greater than this weapon attack's {p}, 
   ],
   "legalFormats": [
     "Blitz",
-    "Classic Constructed",
-    "Golden Age",
-    "Living Legend",
     "Open",
-    "Silver Age",
     "Ultimate Pit Fight",
   ],
   "legalHeroes": [

--- a/packages/cards/tests/legality.test.ts
+++ b/packages/cards/tests/legality.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "@jest/globals";
-import { Card, getCanBeCreated, Hero } from "@flesh-and-blood/types";
+import { Card, Format, getCanBeCreated, Hero } from "@flesh-and-blood/types";
 import { cards } from "../dist/index";
 import {
   getLegalHeroesByCard,
@@ -210,5 +210,27 @@ describe("Macros follow class and talent", () => {
     ],
   ])("%s is legal for its draft heroes", (macroCardIdentifier, heroes) => {
     expect(getLegalHeroes(macroCardIdentifier)).toEqual(heroes);
+  });
+});
+
+describe("Format legality", () => {
+  it.each(["corrupt-and-conquer-red", "open-the-gate-to-iarathael-red"])(
+    "%s honors its Classic Constructed spoiler ban",
+    (cardIdentifier) => {
+      const card = getCard(cardIdentifier);
+
+      expect(card.bannedFormats).toContain(Format.ClassicConstructed);
+      expect(card.legalFormats).not.toContain(Format.ClassicConstructed);
+    },
+  );
+
+  it("Never marks a card as both banned and legal in the same format", () => {
+    const overlappingFormats = cards.flatMap((card) =>
+      (card.bannedFormats ?? [])
+        .filter((format) => card.legalFormats.includes(format))
+        .map((format) => `${card.cardIdentifier}: ${format}`),
+    );
+
+    expect(overlappingFormats).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

- Honor explicit `No` values for Classic Constructed, Living Legend, and Silver Age in spoiler CSVs.
- Make bans take precedence when confirming format legality, so a card cannot be both banned and legal in the same format.
- Regenerate the card exports and snapshots, with regression coverage for Corrupt and Conquer, Open the Gate to i'Arathael, and overlapping banned/legal formats.

## Testing

- `npm test --workspaces --if-present -- --runInBand`
- `git diff --check`

All 25 suites passed: 86,014 tests passed, 5,039 skipped, and 5,053 snapshots passed.

The workspace tests were invoked directly because the local Nx daemon could not compute its project graph.
